### PR TITLE
feat(planner): support structural violations via allow_structural_violations flag

### DIFF
--- a/src/conformly/planner/plan_field.py
+++ b/src/conformly/planner/plan_field.py
@@ -21,7 +21,14 @@ def plan_violation_task(
     allow_type_mismatch: bool = False,
     allow_structural_violations: bool = False,
 ) -> PlannedTask:
+    if _is_extra_field(model, path):
+        if not allow_structural_violations:
+            raise ValueError("EXTRA_FIELD requires allow_structural_violations=True")
+
+        return PlannedTask(path, (ViolationType.EXTRA_FIELD,))
+
     field = model.get_field(path)
+
     return PlannedTask(
         path,
         _define_allowed_violation_types(
@@ -32,6 +39,22 @@ def plan_violation_task(
             allow_structural_violations=allow_structural_violations,
         ),
     )
+
+
+def _is_extra_field(model: ResolvedModel, path: FieldPath) -> bool:
+    if not path:
+        return False
+
+    current = model
+    for _, index in enumerate(path[:-1]):
+        if index >= len(current.fields):
+            return False
+        field = current.fields[index]
+        if field.nested_model is None:
+            return False
+        current = field.nested_model
+
+    return path[-1] == len(current.fields)
 
 
 def _define_allowed_violation_types(

--- a/src/conformly/planner/plan_session.py
+++ b/src/conformly/planner/plan_session.py
@@ -13,8 +13,11 @@ def select_paths(
     allow_all: bool,
     count: int = 1,
     allow_type_mismatch: bool = False,
+    allow_structural_violations: bool = False,
 ) -> tuple[FieldPath, ...]:
-    constrained_fields = _gather_constrained_paths(model, allow_type_mismatch)
+    constrained_fields = _gather_constrained_paths(
+        model, allow_type_mismatch, allow_structural_violations
+    )
 
     if not constrained_fields:
         raise ValueError("Cannot generate invalid case(s): no fields have constraints")
@@ -23,7 +26,9 @@ def select_paths(
 
 
 def _gather_constrained_paths(
-    model: ResolvedModel, allow_type_mismatch: bool = False
+    model: ResolvedModel,
+    allow_type_mismatch: bool = False,
+    allow_structural_violations: bool = False,
 ) -> NameIndexMap:
     result: list[tuple[FieldPath, str]] = []
 
@@ -32,8 +37,10 @@ def _gather_constrained_paths(
             path = (*prefix, i)
             dotted = ".".join([*names, field.name])
 
-            can_violate = field.semantic.has_constraints or (
-                allow_type_mismatch and field.nested_model is None
+            can_violate = (
+                field.semantic.has_constraints
+                or (allow_type_mismatch and field.nested_model is None)
+                or allow_structural_violations
             )
 
             if can_violate:
@@ -41,6 +48,12 @@ def _gather_constrained_paths(
 
             if field.nested_model is not None:
                 dfs(field.nested_model, path, [*names, field.name])
+
+        if allow_structural_violations:
+            extra_index = len(current.fields)
+            extra_path = (*prefix, extra_index)
+            extra_dotted = (".".join(names) + ":extra") if names else ":extra"
+            result.append((extra_path, extra_dotted))
 
     dfs(model, (), [])
     return tuple(result)

--- a/tests/test_planner/test_plan_field.py
+++ b/tests/test_planner/test_plan_field.py
@@ -6,6 +6,7 @@ from conformly.planner.plan_field import (
     _define_allowed_violation_types,
     _define_numeric_violations,
     _define_string_violations,
+    _is_extra_field,
     plan_violation_task,
 )
 from conformly.planner.planned_task import PlannedTask
@@ -574,6 +575,16 @@ def test_plan_violation_task_allow_structural_violations(
     assert plan_violation_task(base_model, path, False, True) == expected
 
 
+@pytest.mark.parametrize(
+    "path",
+    [(3,), (2, 2), (2, 0, 2)],
+)
+def test_plan_violation_task_valid_extra_field(path: FieldPath) -> None:
+    assert plan_violation_task(base_model, path, False, True) == PlannedTask(
+        path, (ViolationType.EXTRA_FIELD,)
+    )
+
+
 @pytest.mark.parametrize("path", [(3,), (0, 1), (2, 2), (2, 1, 4)])
 def test_plan_violation_task_invalid(path: FieldPath) -> None:
     with pytest.raises((IndexError, ValueError)):
@@ -583,3 +594,24 @@ def test_plan_violation_task_invalid(path: FieldPath) -> None:
 def test_plan_violation_task_raises_for_type_mismatch_nested_models() -> None:
     with pytest.raises(NotImplementedError):
         plan_violation_task(base_model, (2,), True)
+
+
+@pytest.mark.parametrize("path", [(5,), (2, 5), (2, 0, 4)])
+def test_plan_violation_task_invalid_extra_field(path: FieldPath) -> None:
+    with pytest.raises((IndexError, ValueError)):
+        plan_violation_task(base_model, path, False, True)
+
+
+# ===== TESTS for _is_extra_field() =====
+
+
+def test_is_extra_field_no_path() -> None:
+    assert not _is_extra_field(base_model, ())
+
+
+def test_is_extra_field_path_longer_than_extra() -> None:
+    assert not _is_extra_field(base_model, (4,))
+
+
+def test_is_extra_field_path_longer_than_extra_nester() -> None:
+    assert not _is_extra_field(base_model, (2, 5))

--- a/tests/test_planner/test_plan_session.py
+++ b/tests/test_planner/test_plan_session.py
@@ -85,3 +85,15 @@ def test_gather_constrained_paths_allow_type_mismatch() -> None:
         ((2,), "is_admin"),
         ((3, 0), "profile.is_blocked"),
     )
+
+
+def test_gather_constrained_paths_allow_structural_violations() -> None:
+    assert _gather_constrained_paths(resolved_model, False, True) == (
+        ((0,), "name"),
+        ((1,), "age"),
+        ((2,), "is_admin"),
+        ((3,), "profile"),
+        ((3, 0), "profile.is_blocked"),
+        ((3, 1), "profile:extra"),
+        ((4,), ":extra"),
+    )


### PR DESCRIPTION
## Summary

Add allow_structural_violations flag in `plan_field.py` and `plan_session.py`.

___

## Related issues

Closes #19 

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [ ] resolver
- [x] planner
- [ ] generators
- [ ] constraints
- [ ] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [ ] ci

---

## Motivation

Prepare session and field planners for adding structural violations flag in core api.

---

## Implementation details

- `MISSING_FIELD` works same as `TYPE_MISMATCH`
- `EXTRA_FIELD` adds one more field to each model/nested model (named ":extra" or "model:extra" for nested)

---

## Breking changes

- [ ] Yes
- [x] No

---

## Tests

- [x] Unit tests added
- [x] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [ ] CHANGELOG updated
- [ ] README updated (if needed)
- [ ] Version increased (if needed)
