### PR TITLE
feat: add pydantic default factory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Deterministic generation** new `seed: int | None = None` parameter in `case()` and `cases()` for reproducible test data
 - **GenerationContext** - immutable context object passed through entire generation pipeline
+- **pydantic default_factory support** - save `callable` object and call it at generation stage
 
 ### Changed
 - **Internal architecture** - all generators now receive `GenerationContext` instead of raw `rng`

--- a/src/conformly/generator/orchestration.py
+++ b/src/conformly/generator/orchestration.py
@@ -93,6 +93,10 @@ def generate_field(
             return None
 
         if field.default is not _UNSET:
+            default = field.default
+            if callable(default):
+                return default()
+
             return field.default
 
         if field.nested_model:

--- a/src/conformly/parsing/adapters/pydantic.py
+++ b/src/conformly/parsing/adapters/pydantic.py
@@ -88,23 +88,17 @@ def parse_field(
         name=name,
         type=runtime_type,
         constraints=all_constraints,
-        default=_parse_default(field_info, name, PydanticUndefined),
+        default=_parse_default(field_info, PydanticUndefined),
         nullable=is_nullable(field_type),
         nested_model=nested_model,
     )
 
 
-def _parse_default(
-    field_info: FieldInfo, field_name: str, PydanticUndefined: Any
-) -> Any:
+def _parse_default(field_info: FieldInfo, PydanticUndefined: Any) -> Any:
     from ...types import _UNSET
 
-    # TODO: inmplement default_factory usage in generator
     if field_info.default_factory is not None:
-        raise NotImplementedError(
-            f"Field '{field_name} uses default_factory, which not supported yet'"
-            f"Track progress in https://github.com/nashabanov/conformly/issues"
-        )
+        return field_info.default_factory
 
     if field_info.default is not PydanticUndefined:
         return field_info.default

--- a/tests/test_integration/test_end_to_end_pydantic.py
+++ b/tests/test_integration/test_end_to_end_pydantic.py
@@ -10,8 +10,6 @@ from conformly import case
 
 
 def test_registry_routes_pydantic_model_to_adapter() -> None:
-    """Smoke-test: Pydantic model → registry → adapter → valid ModelSpec"""
-
     class User(BaseModel):
         name: str = Field(min_length=2, max_length=50)
         age: int = Field(ge=0, le=150)
@@ -21,3 +19,33 @@ def test_registry_routes_pydantic_model_to_adapter() -> None:
     assert 2 <= len(result["name"]) <= 50
     assert 0 <= result["age"] <= 150
     assert result["role"] in ("user", "admin")
+
+
+def test_default_factory() -> None:
+    def factory() -> int:
+        return 42
+
+    class Model(BaseModel):
+        value: int = Field(default_factory=factory)
+
+    result = case(Model, valid=True)
+
+    assert result["value"] == 42
+
+
+def test_default_factory_called_each_time() -> None:
+    counter = 0
+
+    def factory() -> int:
+        nonlocal counter
+        counter += 1
+        return counter
+
+    class Model(BaseModel):
+        value: int = Field(default_factory=factory)
+
+    result1 = case(Model, valid=True)
+    result2 = case(Model, valid=True)
+
+    assert result1["value"] == 1
+    assert result2["value"] == 2

--- a/tests/test_parsing/test_pydantic_adapter.py
+++ b/tests/test_parsing/test_pydantic_adapter.py
@@ -185,7 +185,7 @@ def test_parse_default_valid(field_name: str, expected: Any) -> None:
         required_str: str
 
     field_info = _get_field_info(Model, field_name)
-    result = _parse_default(field_info, field_name, PydanticUndefined)
+    result = _parse_default(field_info, PydanticUndefined)
     assert result == expected
 
 
@@ -195,8 +195,7 @@ def test_parse_default_raises_default_factory() -> None:
 
     field_info = _get_field_info(Model, "list_factory")
 
-    with pytest.raises(NotImplementedError):
-        _parse_default(field_info, "list_factory", NotImplementedError)
+    assert callable(_parse_default(field_info, PydanticUndefined))
 
 
 # ===== TESTS for parse_field() =====


### PR DESCRIPTION
## Summary

Add support for `default_factory` from Pydantic models in the data generation pipeline

___

## Related issues

Closes #12

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [ ] resolver
- [ ] planner
- [x] generators
- [ ] constraints
- [x] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [ ] ci

---

## Implementation details

- `default_factory` is preserved as a `callable` during parsing
- factory is executed only at generation time

---

## Breking changes

- [ ] Yes
- [x] No

---

## Tests

- [x] Unit tests added
- [x] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [x] CHANGELOG updated
- [ ] README updated (if needed)
- [ ] Version increased (if needed)
