### PR TITLE
feat: collection level constraints for list and set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Structured error context** — every exception includes:
   - `message: str` — human-readable description.
   - `context: dict[str, Any]` — machine-readable diagnostic data (e.g., `code`, `field`, `constraint`, `strategy`).
+- **List-level constraints support**:
+  - `MinItems(n)` — minimum number of elements
+  - `MaxItems(n)` — maximum number of elements
+  - `UniqueItems(bool)` — enforce uniqueness of elements
 
 ### Changed
 - **Public API error handling** — functions `case()`, `cases()`, and low-level pipeline stages now raise `GenerationError` or `PlanningError` instead of built-in exceptions. This enables precise `except` clauses and structured logging.
+- **`set[T]` and `frozenset[T]` types are now normalized** to list-based generation with UniqueItems(True) semantics, ensuring deterministic output format and consistent constraint handling across collection types
 
 
 ## [0.3.10] - 2025.04.11

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ If you need **deterministic control** over which exact constraint to violate, th
 | Numeric | `LessOrEqual(v)` | `le=v` |
 | Numeric | `MultipleOf(v)` | `multitiple_of=v` |
 | Closed-set | `OneOf(values)` | `Literal[...]`, `Enum` |
+| Collection | `MinItems(n)` | `min_length=n` (for lists in `Field(...)`) |
+| Collection | `MaxItems(n)` | `max_length=n` (for lists in `Field(...)`) |
+| Collection | `UniqueItems(bool)` | `set[T]`, `frozenset[T]` |
 
 > Important: Pydantic's constr(), conint(), and functional validators are not interpreted as constraints.
 > Use Field() parameters for constraint extraction.
@@ -200,7 +203,7 @@ If you need **deterministic control** over which exact constraint to violate, th
 > You can use for both model types (dataclasses, Pydantic)
 ```python
 from typing import Annotated
-from conformly.constraints import MinLength, GreaterOrEqual
+from conformly import MinLength, GreaterOrEqual
 
 username: Annotated[str, MinLength(3)]
 ```
@@ -379,7 +382,7 @@ print(invalid_data_by_field)
 
 ## Collections
 
-### List support (experimental)
+### List support
 
 `conformly` supports basic generation of `list[T]` where `T` is a constrained primitive or a nested model.
 
@@ -388,7 +391,7 @@ print(invalid_data_by_field)
 ```python
 from dataclasses import dataclass
 from typing import Annotated
-from conformly import case, MinLength
+from conformly import case, MinLength, MaxItems, UniqueItems
 
 @dataclass
 class Product:
@@ -397,22 +400,45 @@ class Product:
 
 @dataclass
 class Order:
-    tags: list[str]                           # list of unconstrained strings
-    codes: Annotated[list[str], MinLength(5)] # each element must be ≥5 chars
-    items: list[Product]                      # list of nested models
+    tags: list[str]                                                   # list of unconstrained strings
+    codes: Annotated[list[Annotated[str, MinLength(5)]], MaxItems(6)] # each element ≥5 chars, max 6 items
+    items: Annotated[list[Product], UniqueItems(True)]                # unique nested models
 
 valid = case(Order, valid=True)
-# -> {"tags": ["abc"], "codes": ["ABCDE"], "items": [{"sku": "...", "price": 10.0}]}
+# -> {
+#   "tags": ["abc", "def"],
+#   "codes": ["ABCDE", "FGHIJ"],
+#   "items": [{"sku": "...", "price": 10.0}]
+# }
 
 invalid = case(Order, valid=False, strategy="codes")
-# -> {"tags": [...], "codes": ["ab", "VALID"], "items": [...]}  # exactly one code violates min_length
+# -> {
+#   "tags": [...],
+#   "codes": ["ab", "VALID"],  # one element violates MinLength
+#   "items": [...]
+# }
 ```
 
-#### Current limitations (v0.3.10)
+### Set and frozenset support
 
-- No `min_items`/`max_items` control (list length is always 1–3 elements)
-- No nested collections (`list[list[T]]` not supported)
-- Invalid generation targets one random element; specific index targeting not available yet
+`set[T]` and `frozenset[T]` are normalized internally to list generation with `UniqueItems(True)` semantics:
+
+```python
+@dataclass
+class Model:
+    tags: set[str]
+
+case(Model)
+# -> {"tags": ["a", "b", "c"]}  # always unique
+```
+
+This ensures consistent output format (list) while preserving uniqueness guarantees.
+
+### Known limitations
+
+- No nested collections (`list[list[T]]` not supported yet)
+- No fine-grained control over which index is violated (random selection only)
+- Uniqueness for non-hashable elements (e.g., dicts) is best-effort (based on structural comparison fallback)
 
 
 ## Development

--- a/src/conformly/__init__.py
+++ b/src/conformly/__init__.py
@@ -9,11 +9,14 @@ from ._internal.constraints import (
     GreaterThan,
     LessOrEqual,
     LessThan,
+    MaxItems,
     MaxLength,
+    MinItems,
     MinLength,
     MultipleOf,
     OneOf,
     Pattern,
+    UniqueItems,
 )
 from ._internal.fields import Email, IPv4, IPv6, IPvAny
 from .exceptions import ConformlyError
@@ -28,11 +31,14 @@ __all__ = [
     "IPvAny",
     "LessOrEqual",
     "LessThan",
+    "MaxItems",
     "MaxLength",
+    "MinItems",
     "MinLength",
     "MultipleOf",
     "OneOf",
     "Pattern",
+    "UniqueItems",
     "case",
     "cases",
 ]

--- a/src/conformly/_internal/constraints/__init__.py
+++ b/src/conformly/_internal/constraints/__init__.py
@@ -1,7 +1,9 @@
 from .base import Constraint
+from .collections import MaxItems, MinItems, UniqueItems
 from .enum import OneOf
 from .keys import (
     ALLOWED_CONSTRAINT_TYPE,
+    COLLECTION_CONSTRAINTS,
     NUMERIC_CONSTRAINTS,
     STRING_CONSTRAINTS,
     ConstraintType,
@@ -12,6 +14,7 @@ from .string import MaxLength, MinLength, Pattern
 
 __all__ = [
     "ALLOWED_CONSTRAINT_TYPE",
+    "COLLECTION_CONSTRAINTS",
     "NUMERIC_CONSTRAINTS",
     "STRING_CONSTRAINTS",
     "Constraint",
@@ -20,10 +23,13 @@ __all__ = [
     "GreaterThan",
     "LessOrEqual",
     "LessThan",
+    "MaxItems",
     "MaxLength",
+    "MinItems",
     "MinLength",
     "MultipleOf",
     "OneOf",
     "Pattern",
+    "UniqueItems",
     "create_constraint",
 ]

--- a/src/conformly/_internal/constraints/base.py
+++ b/src/conformly/_internal/constraints/base.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Constraint:
     """Marker base class for constraints"""

--- a/src/conformly/_internal/constraints/collections.py
+++ b/src/conformly/_internal/constraints/collections.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from .base import Constraint
+
+
+@dataclass(frozen=True)
+class MinItems(Constraint):
+    value: int
+
+    def __repr__(self) -> str:
+        return f"MinItems(value={self.value})"
+
+
+@dataclass(frozen=True)
+class MaxItems(Constraint):
+    value: int
+
+    def __repr__(self) -> str:
+        return f"MaxItems(value={self.value})"
+
+
+@dataclass(frozen=True)
+class UniqueItems(Constraint):
+    is_unique: bool
+
+    def __repr__(self) -> str:
+        return f"UniqueItems(is_unique={self.is_unique})"

--- a/src/conformly/_internal/constraints/collections.py
+++ b/src/conformly/_internal/constraints/collections.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from .base import Constraint
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MinItems(Constraint):
     value: int
 
@@ -11,7 +11,7 @@ class MinItems(Constraint):
         return f"MinItems(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MaxItems(Constraint):
     value: int
 
@@ -19,7 +19,7 @@ class MaxItems(Constraint):
         return f"MaxItems(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class UniqueItems(Constraint):
     is_unique: bool
 

--- a/src/conformly/_internal/constraints/enum.py
+++ b/src/conformly/_internal/constraints/enum.py
@@ -4,6 +4,6 @@ from typing import Any
 from .base import Constraint
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class OneOf(Constraint):
     values: tuple[Any, ...]

--- a/src/conformly/_internal/constraints/keys.py
+++ b/src/conformly/_internal/constraints/keys.py
@@ -4,9 +4,23 @@ STRING_CONSTRAINTS = frozenset({"min_length", "max_length", "pattern"})
 
 NUMERIC_CONSTRAINTS = frozenset({"gt", "ge", "lt", "le", "multiple_of"})
 
+COLLECTION_CONSTRAINTS = frozenset({"min_items", "max_items", "unique_items"})
 
-ALLOWED_CONSTRAINT_TYPE = STRING_CONSTRAINTS | NUMERIC_CONSTRAINTS
+
+ALLOWED_CONSTRAINT_TYPE = (
+    STRING_CONSTRAINTS | NUMERIC_CONSTRAINTS | COLLECTION_CONSTRAINTS
+)
 
 ConstraintType = Literal[
-    "min_length", "max_length", "pattern", "gt", "ge", "lt", "le", "multiple_of"
+    "min_length",
+    "max_length",
+    "pattern",
+    "gt",
+    "ge",
+    "lt",
+    "le",
+    "multiple_of",
+    "min_items",
+    "max_items",
+    "unique_items",
 ]

--- a/src/conformly/_internal/constraints/mapping.py
+++ b/src/conformly/_internal/constraints/mapping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from .collections import MaxItems, MinItems, UniqueItems
 from .numeric import GreaterOrEqual, GreaterThan, LessOrEqual, LessThan, MultipleOf
 from .string import MaxLength, MinLength, Pattern
 
@@ -22,6 +23,9 @@ CONSTRAINT_MAPPING: dict[ConstraintType, Callable[[Any], Constraint]] = {
     "min_length": MinLength,
     "pattern": Pattern,
     "multiple_of": MultipleOf,
+    "min_items": MinItems,
+    "max_items": MaxItems,
+    "unique_items": UniqueItems,
 }
 
 

--- a/src/conformly/_internal/constraints/numeric.py
+++ b/src/conformly/_internal/constraints/numeric.py
@@ -5,7 +5,7 @@ from .base import Constraint
 TNum = int | float
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class GreaterThan(Constraint):
     value: TNum
 
@@ -13,7 +13,7 @@ class GreaterThan(Constraint):
         return f"GreaterThan(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class GreaterOrEqual(Constraint):
     value: TNum
 
@@ -21,7 +21,7 @@ class GreaterOrEqual(Constraint):
         return f"GreaterOrEqual(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LessThan(Constraint):
     value: TNum
 
@@ -29,7 +29,7 @@ class LessThan(Constraint):
         return f"LessThan(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class LessOrEqual(Constraint):
     value: TNum
 
@@ -37,7 +37,7 @@ class LessOrEqual(Constraint):
         return f"LessOrEqual(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MultipleOf(Constraint):
     value: TNum
 

--- a/src/conformly/_internal/constraints/string.py
+++ b/src/conformly/_internal/constraints/string.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from .base import Constraint
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MinLength(Constraint):
     value: int
 
@@ -11,7 +11,7 @@ class MinLength(Constraint):
         return f"MinLength(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class MaxLength(Constraint):
     value: int
 
@@ -19,7 +19,7 @@ class MaxLength(Constraint):
         return f"MaxLength(value={self.value})"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class Pattern(Constraint):
     regex: str
 

--- a/src/conformly/_internal/generator/types/list.py
+++ b/src/conformly/_internal/generator/types/list.py
@@ -2,44 +2,158 @@ from typing import Any
 
 from ..context import GenerationContext
 
-from conformly._internal.resolver.semantics import ListSemantic
+from conformly._internal.resolver import ResolvedModel
+from conformly._internal.resolver.semantics import FieldSemantics, ListSemantic
 from conformly._internal.types import UNSET, ViolationType
 
 
 def generate_value(
     ctx: GenerationContext, semantic: ListSemantic, violation: ViolationType | None
 ) -> list[Any]:
+    return (
+        _generate_valid_list(ctx, semantic)
+        if not violation
+        else _generate_invalid_list(ctx, semantic, violation)
+    )
+
+
+def _generate_valid_list(ctx: GenerationContext, semantic: ListSemantic) -> list[Any]:
+    min_len, max_len = _calculate_valid_range(semantic)
+
+    length = ctx.rng.randint(min_len, max_len)
+
+    result: list[Any] = []
+
+    if not semantic.is_unique_items:
+        for _ in range(length):
+            item = _generate_list_item(
+                ctx, semantic.element_semantic, semantic.element_nested_model, None
+            )
+            result.append(item)
+
+    seen = set()
+    max_attempts = 20
+
+    while len(result) < length and max_attempts > 0:
+        item = _generate_list_item(
+            ctx, semantic.element_semantic, semantic.element_nested_model, None
+        )
+
+        if not _is_hashable(item):
+            result.append(item)
+            continue
+
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+
+        max_attempts -= 1
+
+    return result
+
+
+def _generate_invalid_list(
+    ctx: GenerationContext, semantic: ListSemantic, violation: ViolationType
+) -> list[Any]:
+    min_len, max_len = _calculate_valid_range(semantic)
+
+    result: list[Any] = []
+
+    match violation:
+        case ViolationType.TOO_LESS_ITEMS:
+            length = max(0, min_len - 1)
+            return [
+                _generate_list_item(
+                    ctx, semantic.element_semantic, semantic.element_nested_model, None
+                )
+                for _ in range(length)
+            ]
+
+        case ViolationType.TOO_MANY_ITEMS:
+            length = max_len + 1
+            return [
+                _generate_list_item(
+                    ctx, semantic.element_semantic, semantic.element_nested_model, None
+                )
+                for _ in range(length)
+            ]
+
+        case ViolationType.DUPLICATE:
+            base = _generate_valid_list(ctx, semantic)
+
+            if not base:
+                item = _generate_list_item(
+                    ctx, semantic.element_semantic, semantic.element_nested_model, None
+                )
+                return [item, item]
+
+            duplicate_idx = ctx.rng.randint(0, len(base) - 1)
+            base.append(base[duplicate_idx])
+
+            return base
+
+        case _:
+            length = ctx.rng.randint(min_len, max_len)
+            violate_idx = ctx.rng.randint(0, length - 1)
+            for i in range(length):
+                item_violation = (violation,) if i == violate_idx else None
+                item = _generate_list_item(
+                    ctx,
+                    semantic.element_semantic,
+                    semantic.element_nested_model,
+                    item_violation,
+                )
+                result.append(item)
+
+    return result
+
+
+def _generate_list_item(
+    ctx: GenerationContext,
+    item_semantic: FieldSemantics,
+    item_nested_model: ResolvedModel | None,
+    violations: tuple[ViolationType, ...] | None,
+) -> Any:
     from ..orchestration import generate_field
 
     from conformly._internal.parser import FieldSpec
     from conformly._internal.resolver import ResolvedField
 
-    length = ctx.rng.randint(1, 3)
-    violate_idx = ctx.rng.randint(0, length - 1) if violation else None
+    mock_spec = FieldSpec(
+        name="__list_item",
+        field_type=object,
+        constraints=(),
+        default=UNSET,
+        nullable=False,
+    )
 
-    result: list[Any] = []
+    elem_field = ResolvedField(
+        field_spec=mock_spec,
+        path=(),
+        semantic=item_semantic,
+        nested_model=item_nested_model,
+    )
 
-    for i in range(length):
-        elem_violation = violation if i == violate_idx else None
-        violations = (elem_violation,) if elem_violation else None
+    return generate_field(ctx, elem_field, violations)
 
-        mock_spec = FieldSpec(
-            name="__list_item",
-            field_type=object,
-            constraints=(),
-            default=UNSET,
-            nullable=False,
-        )
 
-        elem_field = ResolvedField(
-            field_spec=mock_spec,
-            path=(),
-            semantic=semantic.element_semantic,
-            nested_model=semantic.element_nested_model,
-        )
+def _calculate_valid_range(semantic: ListSemantic) -> tuple[int, int]:
+    if semantic.length_range is None:
+        min_len = 1
+        max_len = 3
+    else:
+        min_len = semantic.length_range.min_length or 1
+        max_len = semantic.length_range.max_length or 3
 
-        value = generate_field(ctx, elem_field, violations)
+    if min_len == 0:
+        min_len = 1
 
-        result.append(value)
+    return min_len, max_len
 
-    return result
+
+def _is_hashable(value: Any) -> bool:
+    try:
+        hash(value)
+        return True
+    except TypeError:
+        return False

--- a/src/conformly/_internal/parser/adapters/dataclass.py
+++ b/src/conformly/_internal/parser/adapters/dataclass.py
@@ -10,6 +10,7 @@ from ..extractors.constraints import (
     is_constraints_consistent,
     parse_annotated_constraints,
     parse_metadata_constraints,
+    split_collection_constraints,
 )
 from ..extractors.types import extract_runtime_type_and_constraints, is_nullable
 from ..models import FieldSpec, ModelSpec
@@ -70,6 +71,10 @@ def parse_field(field: Field[Any], field_type: Any) -> FieldSpec:
             },
         )
 
+    element_constraints, collection_constraints = split_collection_constraints(
+        all_constraints
+    )
+
     nested_model = (
         parse(runtime_type)
         if runtime_type is not ENUMERATED_TYPE and supports(runtime_type)
@@ -79,11 +84,12 @@ def parse_field(field: Field[Any], field_type: Any) -> FieldSpec:
     return FieldSpec(
         name=field.name,
         field_type=runtime_type,
-        constraints=all_constraints,
+        constraints=element_constraints,
         default=parse_defaults(field),
         nullable=is_nullable(field_type),
         nested_model=nested_model,
         collection_type=collection_type,
+        collection_constraints=collection_constraints,
     )
 
 

--- a/src/conformly/_internal/parser/adapters/pydantic.py
+++ b/src/conformly/_internal/parser/adapters/pydantic.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import TYPE_CHECKING, Annotated, Any, get_args, get_origin
 
-from ...fields import SPECIAL_NAME_TO_TYPE
 from ..models import FieldSpec, ModelSpec
 
+from conformly._internal.fields import SPECIAL_NAME_TO_TYPE
 from conformly.exceptions import ResolutionError, SchemaError
 
 if TYPE_CHECKING:
-    from ...constraints import Constraint
     from pydantic import BaseModel
     from pydantic.fields import FieldInfo
+
+    from conformly._internal.constraints import Constraint
 
 
 def supports(model: type) -> bool:
@@ -64,11 +65,13 @@ def parse_fields(
 def parse_field(
     field_info: FieldInfo, field_type: Any, name: str, PydanticUndefined: Any
 ) -> FieldSpec:
-    from ...types import ENUMERATED_TYPE
     from ..extractors.constraints import (
         is_constraints_consistent,
+        split_collection_constraints,
     )
     from ..extractors.types import extract_runtime_type_and_constraints, is_nullable
+
+    from conformly._internal.types import ENUMERATED_TYPE
 
     runtime_type, intrinsic_constraints, collection_type = (
         extract_runtime_type_and_constraints(field_type, name)
@@ -92,6 +95,10 @@ def parse_field(
             },
         )
 
+    element_constraints, collection_constraints = split_collection_constraints(
+        all_constraints
+    )
+
     nested_model = (
         parse(resolved_type)
         if resolved_type is not ENUMERATED_TYPE and supports(resolved_type)
@@ -101,11 +108,12 @@ def parse_field(
     return FieldSpec(
         name=name,
         field_type=resolved_type,
-        constraints=all_constraints,
+        constraints=element_constraints,
         default=_parse_default(field_info, PydanticUndefined),
         nullable=is_nullable(field_type),
         nested_model=nested_model,
         collection_type=collection_type,
+        collection_constraints=collection_constraints,
     )
 
 
@@ -121,7 +129,7 @@ def _resolve_pydantic_special_type(field_type: Any) -> Any:
 
 
 def _parse_default(field_info: FieldInfo, PydanticUndefined: Any) -> Any:
-    from ...types import UNSET
+    from conformly._internal.types import UNSET
 
     if field_info.default_factory is not None:
         return field_info.default_factory
@@ -133,10 +141,17 @@ def _parse_default(field_info: FieldInfo, PydanticUndefined: Any) -> Any:
 
 
 def _parse_fieldinfo_constraints(field_info: FieldInfo) -> tuple[Constraint, ...]:
-    from ...constraints import ALLOWED_CONSTRAINT_TYPE, Constraint, create_constraint
     from ..extractors.constraints import _validate_constraint_type
 
+    from conformly._internal.constraints import (
+        ALLOWED_CONSTRAINT_TYPE,
+        Constraint,
+        create_constraint,
+    )
+
     constraints: list[Constraint] = []
+    origin = get_origin(field_info.annotation)
+    is_collection = origin in (list, set, frozenset)
 
     for meta in field_info.metadata:
         if isinstance(meta, Constraint):
@@ -152,7 +167,13 @@ def _parse_fieldinfo_constraints(field_info: FieldInfo) -> tuple[Constraint, ...
                 if attr == "pattern":
                     value = getattr(value, "pattern", value)
 
-                constraint = create_constraint(_validate_constraint_type(attr), value)
+                target_attr = attr
+                if is_collection and attr in ("min_length", "max_length"):
+                    target_attr = "min_items" if attr == "min_length" else "max_items"
+
+                constraint = create_constraint(
+                    _validate_constraint_type(target_attr), value
+                )
                 constraints.append(constraint)
 
     return tuple(constraints)

--- a/src/conformly/_internal/parser/extractors/constraints.py
+++ b/src/conformly/_internal/parser/extractors/constraints.py
@@ -76,13 +76,30 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
     if k == "pattern":
         return str(v)
 
-    if k in STRING_CONSTRAINTS:
-        if isinstance(v, int):
+    if k == "unique_items":
+        if isinstance(v, bool):
             return v
         if isinstance(v, str):
-            s = v.strip()
+            return v.strip().lower() in ("true", "1", "yes")
+        if isinstance(v, (int, float)):
+            return bool(v)
+        raise SchemaError(
+            f"Constraint '{k}' expects boolean value",
+            context={
+                "code": "invalid_constraint_value",
+                "constraint_type": k,
+                "value": v,
+                "expected": bool,
+                "actual": type(v).__name__,
+            },
+        )
+
+    if k in STRING_CONSTRAINTS:
+        if isinstance(v, int) and not isinstance(v, bool):
+            return v
+        if isinstance(v, str):
             try:
-                return int(s)
+                return int(v.strip())
             except ValueError as e:
                 raise SchemaError(
                     f"Constraint '{k}' expects integer value",
@@ -105,17 +122,17 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
         )
 
     if k in NUMERIC_CONSTRAINTS:
-        if isinstance(v, (int, float)):
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
             return v
         if isinstance(v, str):
             s = v.strip()
             try:
-                if all(ch.isdigit() for ch in s.lstrip("+-")):
-                    return int(s)
-                return float(s)
+                return (
+                    int(s) if all(ch.isdigit() for ch in s.lstrip("+-")) else float(s)
+                )
             except ValueError as e:
                 raise SchemaError(
-                    f"Constraint '{k}' expects numetic value",
+                    f"Constraint '{k}' expects numeric value",
                     context={
                         "code": "invalid_constraint_value",
                         "constraint_type": k,
@@ -124,7 +141,7 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
                     },
                 ) from e
         raise SchemaError(
-            f"Constraint '{k}' expects numetic value",
+            f"Constraint '{k}' expects numeric value",
             context={
                 "code": "invalid_constraint_value",
                 "constraint_type": k,
@@ -143,7 +160,7 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
                     return int(v.strip())
                 except ValueError as e:
                     raise SchemaError(
-                        f"Constraint '{k}' expects numetic value",
+                        f"Constraint '{k}' expects numeric value",
                         context={
                             "code": "invalid_constraint_value",
                             "constraint_type": k,
@@ -152,30 +169,12 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
                         },
                     ) from e
         raise SchemaError(
-            f"Constraint '{k}' expects numetic value",
+            f"Constraint '{k}' expects numeric value",
             context={
                 "code": "invalid_constraint_value",
                 "constraint_type": k,
                 "value": v,
                 "expected": "number",
-                "actual": type(v).__name__,
-            },
-        )
-
-    if k == "unique_items":
-        if isinstance(v, bool):
-            return v
-        if isinstance(v, str):
-            return v.strip().lower() in ("true", "1", "yes")
-        if isinstance(v, (float, int)):
-            return bool(v)
-        raise SchemaError(
-            f"Constraint '{k}' expects boolean value",
-            context={
-                "code": "invalid_constraint_value",
-                "constraint_type": k,
-                "value": v,
-                "expected": bool,
                 "actual": type(v).__name__,
             },
         )

--- a/src/conformly/_internal/parser/extractors/constraints.py
+++ b/src/conformly/_internal/parser/extractors/constraints.py
@@ -1,22 +1,42 @@
 from collections.abc import Mapping
 from typing import Annotated, Any, cast, get_args, get_origin
 
-from ...constraints import (
+from conformly._internal.constraints import (
     ALLOWED_CONSTRAINT_TYPE,
+    COLLECTION_CONSTRAINTS,
     NUMERIC_CONSTRAINTS,
     STRING_CONSTRAINTS,
     Constraint,
     ConstraintType,
+    MaxItems,
+    MinItems,
     OneOf,
+    UniqueItems,
     create_constraint,
 )
-
 from conformly.exceptions import SchemaError
+
+_COLLECTION_CONTRAINTS_TYPE = (MinItems, MaxItems, UniqueItems)
 
 
 def is_constraints_consistent(constraints: tuple[Constraint, ...]) -> bool:
     has_one_of = any(isinstance(c, OneOf) for c in constraints)
     return not has_one_of or len(constraints) == 1
+
+
+def split_collection_constraints(
+    constraints: tuple[Constraint, ...],
+) -> tuple[tuple[Constraint, ...], tuple[Constraint, ...]]:
+    collection_constraints = []
+    element_constraints = []
+
+    for c in constraints:
+        if isinstance(c, _COLLECTION_CONTRAINTS_TYPE):
+            collection_constraints.append(c)
+        else:
+            element_constraints.append(c)
+
+    return tuple(element_constraints), tuple(collection_constraints)
 
 
 def parse_annotated_constraints(field_type: Any) -> tuple[Constraint, ...]:
@@ -110,6 +130,52 @@ def _coerce_constraint_value(k: ConstraintType, v: Any) -> Any:
                 "constraint_type": k,
                 "value": v,
                 "expected": "number",
+                "actual": type(v).__name__,
+            },
+        )
+
+    if k in COLLECTION_CONSTRAINTS:
+        if k in ("min_items", "max_items"):
+            if isinstance(v, int) and not isinstance(v, bool):
+                return v
+            if isinstance(v, str):
+                try:
+                    return int(v.strip())
+                except ValueError as e:
+                    raise SchemaError(
+                        f"Constraint '{k}' expects numetic value",
+                        context={
+                            "code": "invalid_constraint_value",
+                            "constraint_type": k,
+                            "value": v,
+                            "expected": "number",
+                        },
+                    ) from e
+        raise SchemaError(
+            f"Constraint '{k}' expects numetic value",
+            context={
+                "code": "invalid_constraint_value",
+                "constraint_type": k,
+                "value": v,
+                "expected": "number",
+                "actual": type(v).__name__,
+            },
+        )
+
+    if k == "unique_items":
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, str):
+            return v.strip().lower() in ("true", "1", "yes")
+        if isinstance(v, (float, int)):
+            return bool(v)
+        raise SchemaError(
+            f"Constraint '{k}' expects boolean value",
+            context={
+                "code": "invalid_constraint_value",
+                "constraint_type": k,
+                "value": v,
+                "expected": bool,
                 "actual": type(v).__name__,
             },
         )

--- a/src/conformly/_internal/parser/extractors/types.py
+++ b/src/conformly/_internal/parser/extractors/types.py
@@ -1,22 +1,20 @@
 from enum import Enum
 from types import UnionType
-from typing import (  # noqa: UP035
+from typing import (
     Annotated,
     Any,
-    List,
     Literal,
     Union,
     get_args,
     get_origin,
 )
 
-from ...constraints import Constraint, OneOf
-from ...types import ENUMERATED_TYPE
-
+from conformly._internal.constraints import Constraint, OneOf, UniqueItems
+from conformly._internal.types import ENUMERATED_TYPE
 from conformly.exceptions import SchemaError
 
 UNION_TYPES = (Union, UnionType)
-COLLECTION_ORIGINS = (list, List)  # noqa: UP006
+COLLECTION_ORIGINS = (list, set, frozenset)
 
 
 def extract_runtime_type_and_constraints(
@@ -50,6 +48,9 @@ def extract_runtime_type_and_constraints(
         else:
             element_type = element_annotation
             element_constraints = ()
+
+        if origin in (set, frozenset):
+            return element_type, (UniqueItems(True),), origin
 
         return element_type, element_constraints or outer_constraints, origin
 

--- a/src/conformly/_internal/parser/models.py
+++ b/src/conformly/_internal/parser/models.py
@@ -18,6 +18,7 @@ class FieldSpec:
     nullable: bool = False
     nested_model: ModelSpec | None = None
     collection_type: type | None = None
+    collection_constraints: tuple[Constraint, ...] = ()
 
     def has_default(self) -> bool:
         return self.default is not UNSET
@@ -37,6 +38,10 @@ class FieldSpec:
             parts.append(f"constraints={[repr(c) for c in self.constraints]!r}")
         if self.nested_model:
             parts.append(f"nested_model={self.nested_model!r}")
+        if self.collection_type:
+            parts.append(f"collection_type={self.collection_type!r}")
+        if self.collection_constraints:
+            parts.append(f"collection_constraints={self.collection_constraints!r}")
 
         return f"Field({', '.join(parts)})"
 

--- a/src/conformly/_internal/parser/models.py
+++ b/src/conformly/_internal/parser/models.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from ..constraints import Constraint
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FieldSpec:
     name: str
     field_type: type
@@ -49,7 +49,7 @@ class FieldSpec:
 ModelType = Literal["dataclass", "pydantic"]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ModelSpec:
     name: str
     type: ModelType

--- a/src/conformly/_internal/planner/field.py
+++ b/src/conformly/_internal/planner/field.py
@@ -28,6 +28,9 @@ _VIOLATION_PRIORITY: tuple[ViolationType, ...] = (
     ViolationType.TYPE_MISMATCH,
     ViolationType.NONE_FOR_NOT_OPTIONAL,
     # Semantic
+    ViolationType.DUPLICATE,
+    ViolationType.TOO_LESS_ITEMS,
+    ViolationType.TOO_MANY_ITEMS,
     ViolationType.BELOW_MIN,
     ViolationType.ABOVE_MAX,
     ViolationType.NOT_MULTIPLE,

--- a/src/conformly/_internal/planner/field.py
+++ b/src/conformly/_internal/planner/field.py
@@ -116,13 +116,8 @@ def _define_allowed_violation_types(
         case NumericSemantic(kind=(FieldKind.INTEGER | FieldKind.FLOAT)):
             violations = _define_numeric_violations(semantic)
 
-        case ListSemantic(element_semantic=elem_sem):
-            try:
-                violations = list(
-                    _define_allowed_violation_types(elem_sem, False, False)
-                )
-            except PlanningError:
-                violations = []
+        case ListSemantic(kind=FieldKind.LIST):
+            violations = _define_list_violations(semantic)
 
         case EnumSemantic(kind=FieldKind.ENUM):
             violations = [ViolationType.NOT_ALLOWED_VALUE]
@@ -213,3 +208,26 @@ def _define_string_violations(
         result.append(ViolationType.PATTERN_MISMATCH)
 
     return result
+
+
+def _define_list_violations(semantic: ListSemantic) -> list[ViolationType]:
+    collection_violations: list[ViolationType] = []
+
+    try:
+        type_violations = list(
+            _define_allowed_violation_types(semantic.element_semantic, False, False)
+        )
+    except PlanningError:
+        type_violations = []
+
+    if semantic.is_unique_items is True:
+        collection_violations.append(ViolationType.DUPLICATE)
+
+    if semantic.length_range is not None:
+        if semantic.length_range.min_length > 0:
+            collection_violations.append(ViolationType.TOO_LESS_ITEMS)
+
+        if semantic.length_range.max_length is not None:
+            collection_violations.append(ViolationType.TOO_MANY_ITEMS)
+
+    return [*collection_violations, *type_violations]

--- a/src/conformly/_internal/planner/model.py
+++ b/src/conformly/_internal/planner/model.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from conformly._internal.types import FieldPath, ViolationType
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class PlannedTask:
     path: FieldPath
     allowed_violations: tuple[ViolationType, ...]

--- a/src/conformly/_internal/resolver/models.py
+++ b/src/conformly/_internal/resolver/models.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from conformly._internal.types import FieldPath
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResolvedField:
     field_spec: FieldSpec
     path: FieldPath
@@ -36,7 +36,7 @@ class ResolvedField:
         return self.field_spec.nullable
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ResolvedModel:
     name: str
     fields: tuple[ResolvedField, ...]

--- a/src/conformly/_internal/resolver/resolve.py
+++ b/src/conformly/_internal/resolver/resolve.py
@@ -21,11 +21,14 @@ from conformly._internal.constraints import (
     GreaterThan,
     LessOrEqual,
     LessThan,
+    MaxItems,
     MaxLength,
+    MinItems,
     MinLength,
     MultipleOf,
     OneOf,
     Pattern,
+    UniqueItems,
 )
 from conformly._internal.fields import (
     SPECIAL_KINDS,
@@ -68,7 +71,8 @@ def resolve_field(field_spec: FieldSpec, path: FieldPath) -> ResolvedField:
     list_semantic = None
 
     if field_spec.collection_type is list:
-        list_semantic = ListSemantic(
+        list_semantic = create_list_semantics(
+            constraints=field_spec.collection_constraints,
             element_semantic=create_field_semantic(field_spec),
             element_nested_model=resolved_nested,
         )
@@ -459,3 +463,48 @@ def extract_enum_included_values(
                     "constraints_got": repr(constraints[0]),
                 },
             )
+
+
+def create_list_semantics(
+    constraints: tuple[Constraint, ...],
+    element_semantic: FieldSemantics,
+    element_nested_model: ResolvedModel | None,
+) -> ListSemantic:
+    has_constraints = len(constraints) > 0
+    min_length = 0
+    max_length = None
+    is_unique_items = False
+
+    for c in constraints:
+        if not isinstance(c, (MinItems, MaxItems, UniqueItems)):
+            continue
+
+        match c:
+            case MinItems(v):
+                if min_length == 0 or v > min_length:
+                    min_length = v
+
+            case MaxItems(v):
+                if max_length is None or v < int(max_length):
+                    max_length = v
+
+            case UniqueItems(v):
+                is_unique_items = v
+
+    if max_length and min_length > max_length:
+        raise SchemaError(
+            "Invalid collection length range",
+            context={
+                "code": "invalid_length_range",
+                "min_length": min_length,
+                "max_length": max_length,
+            },
+        )
+
+    return ListSemantic(
+        element_semantic=element_semantic,
+        element_nested_model=element_nested_model,
+        length_range=LengthRange(min_length, max_length),
+        is_unique_items=is_unique_items,
+        has_constraints=has_constraints,
+    )

--- a/src/conformly/_internal/resolver/resolve.py
+++ b/src/conformly/_internal/resolver/resolve.py
@@ -70,7 +70,7 @@ def resolve_field(field_spec: FieldSpec, path: FieldPath) -> ResolvedField:
     )
     list_semantic = None
 
-    if field_spec.collection_type is list:
+    if field_spec.collection_type in (list, set, frozenset):
         list_semantic = create_list_semantics(
             constraints=field_spec.collection_constraints,
             element_semantic=create_field_semantic(field_spec),

--- a/src/conformly/_internal/resolver/semantics/list.py
+++ b/src/conformly/_internal/resolver/semantics/list.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from .base import BaseSemantic
 
-from conformly._internal.types import FieldKind
+from conformly._internal.types import FieldKind, LengthRange
 
 if TYPE_CHECKING:
     from ..models import ResolvedModel
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 class ListSemantic(BaseSemantic):
     element_semantic: "FieldSemantics"
     element_nested_model: "ResolvedModel | None" = None
+    length_range: LengthRange | None = None
+    is_unique_items: bool = False
 
     @property
     def kind(self) -> FieldKind:

--- a/src/conformly/_internal/types/primitives.py
+++ b/src/conformly/_internal/types/primitives.py
@@ -56,6 +56,11 @@ class ViolationType(Enum):
     # Enum
     NOT_ALLOWED_VALUE = "not_allowed_value"
 
+    # collections
+    TOO_LESS_ITEMS = "too_less_items"
+    TOO_MANY_ITEMS = "too_many_items"
+    DUPLICATE = "duplicate"
+
     # structural
     MISSING_FIELD = "missing_field"
     EXTRA_FIELD = "extra_field"

--- a/tests/test_generator/test_types_generators/test_list_generator.py
+++ b/tests/test_generator/test_types_generators/test_list_generator.py
@@ -112,3 +112,113 @@ def test_no_violation_passed_when_none(ctx, list_sem) -> None:
         generate_value(ctx, list_sem, violation=None)
 
         assert all(c.args[2] is None for c in mock_gen.call_args_list)
+
+
+def test_unique_items_enforced(ctx, mock_elem_semantic) -> None:
+    semantic = ListSemantic(
+        element_semantic=mock_elem_semantic,
+        is_unique_items=True,
+    )
+
+    ctx.rng.randint = Mock(return_value=3)
+
+    values = ["a", "a", "b", "c"]
+
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        side_effect=values,
+    ):
+        result = generate_value(ctx, semantic, None)
+
+        assert len(result) == 3
+        assert len(set(result)) == 3
+
+
+def test_unique_items_with_unhashable_values(ctx, mock_elem_semantic) -> None:
+    semantic = ListSemantic(
+        element_semantic=mock_elem_semantic,
+        is_unique_items=True,
+    )
+
+    ctx.rng.randint = Mock(return_value=2)
+
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        return_value={"a": 1},
+    ):
+        result = generate_value(ctx, semantic, None)
+
+        assert len(result) == 2
+
+
+def test_too_less_items_violation(ctx, list_sem) -> None:
+    ctx.rng.randint = Mock()
+
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        return_value="v",
+    ):
+        result = generate_value(ctx, list_sem, ViolationType.TOO_LESS_ITEMS)
+
+        assert result == []
+
+
+def test_too_many_items_violation(ctx, list_sem) -> None:
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        return_value="v",
+    ) as mock_gen:
+        result = generate_value(ctx, list_sem, ViolationType.TOO_MANY_ITEMS)
+
+        assert len(result) == 4
+        assert mock_gen.call_count == 4
+
+
+def test_duplicate_violation_creates_duplicate(ctx, mock_elem_semantic) -> None:
+    semantic = ListSemantic(
+        element_semantic=mock_elem_semantic,
+        is_unique_items=True,
+    )
+
+    ctx.rng.randint = Mock(side_effect=[2, 0])
+
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        side_effect=["a", "b"],
+    ):
+        result = generate_value(ctx, semantic, ViolationType.DUPLICATE)
+
+        assert len(result) == 3
+        assert len(set(result)) < len(result)
+
+
+def test_duplicate_violation_on_empty_base(ctx, list_sem) -> None:
+    with (
+        patch(
+            "conformly._internal.generator.types.list._generate_valid_list",
+            return_value=[],
+        ),
+        patch(
+            "conformly._internal.generator.orchestration.generate_field",
+            return_value="x",
+        ),
+    ):
+        result = generate_value(ctx, list_sem, ViolationType.DUPLICATE)
+
+        assert result == ["x", "x"]
+
+
+def test_non_collection_violation_still_targets_single_item(ctx, list_sem) -> None:
+    ctx.rng.randint = Mock(side_effect=[3, 2])
+
+    with patch(
+        "conformly._internal.generator.orchestration.generate_field",
+        return_value="v",
+    ) as mock_gen:
+        generate_value(ctx, list_sem, ViolationType.TOO_SHORT)
+
+        calls = mock_gen.call_args_list
+
+        assert calls[0].args[2] is None
+        assert calls[1].args[2] is None
+        assert calls[2].args[2] == (ViolationType.TOO_SHORT,)

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -11,9 +11,11 @@ from conformly import (
     GreaterThan,
     LessOrEqual,
     LessThan,
+    MaxItems,
     MaxLength,
     MinLength,
     Pattern,
+    UniqueItems,
     case,
     cases,
 )
@@ -90,9 +92,9 @@ class ProductItem:
 
 @dataclass
 class Order:
-    items: list[ProductItem]
-    tags: list[str]
-    codes: Annotated[list[str], MinLength(5)]
+    items: Annotated[list[ProductItem], UniqueItems(True)]
+    tags: set[str]
+    codes: Annotated[list[Annotated[str, MinLength(5)]], MaxItems(6)]
     flags: list[bool]
 
 
@@ -696,6 +698,60 @@ class TestListGeneration:
 
         assert isinstance(result["flags"], list)
         assert all(isinstance(f, bool) for f in result["flags"])
+
+    def test_tags_are_unique_strings(self):
+        result = case(Order, valid=True)
+
+        tags = result["tags"]
+
+        assert isinstance(tags, list)
+        assert 1 <= len(tags) <= 3
+        assert all(isinstance(t, str) for t in tags)
+
+        assert len(tags) == len(set(tags))
+
+    def test_codes_constraints_enforced(self):
+        result = case(Order, valid=True)
+
+        codes = result["codes"]
+
+        assert isinstance(codes, list)
+        assert 1 <= len(codes) <= 6
+
+        for code in codes:
+            assert isinstance(code, str)
+            assert len(code) >= 5
+
+    def test_items_are_unique_and_valid(self):
+        result = case(Order, valid=True)
+
+        items = result["items"]
+
+        assert isinstance(items, list)
+        assert len(items) >= 1
+
+        for item in items:
+            assert isinstance(item, dict)
+            assert "sku" in item and "price" in item
+            assert isinstance(item["sku"], str)
+            assert item["price"] >= 0
+
+        assert len(items) == len({repr(i) for i in items})
+
+    def test_items_duplicate_violation(self):
+        result = case(Order, valid=False)
+
+        items = result["items"]
+
+        if len(items) > 1:
+            assert len(items) != len({repr(i) for i in items})
+
+    def test_codes_length_violation(self):
+        result = case(Order, valid=False, strategy="codes")
+
+        codes = result["codes"]
+
+        assert len(codes) > 6 or len(codes) == 0
 
 
 class TestUUIDGeneration:

--- a/tests/test_parsing/test_constraints_extractors.py
+++ b/tests/test_parsing/test_constraints_extractors.py
@@ -1,16 +1,18 @@
 from dataclasses import dataclass, field, fields
-from typing import Annotated
+from typing import Annotated, Any
 
 import pytest
 
 from conformly._internal.constraints import (
     Constraint,
+    ConstraintType,
     GreaterOrEqual,
     MinLength,
     OneOf,
     Pattern,
 )
 from conformly._internal.parser.extractors.constraints import (
+    _coerce_constraint_value,
     _metadata_to_constraints,
     is_constraints_consistent,
     parse_annotated_constraints,
@@ -141,3 +143,107 @@ def test_is_constraints_consistent_valid():
 def test_is_constraints_consistent_invalid():
     constraints = (OneOf((1, 2)), GreaterOrEqual(1))
     assert not is_constraints_consistent(constraints)
+
+
+# ====== TESTS for _coerce_constraint_value() =====
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("hello", "hello"),
+        (123, "123"),
+        (3.14, "3.14"),
+        (None, "None"),
+        (True, "True"),
+    ],
+)
+def test_pattern_coerces_to_string(value: Any, expected: str) -> None:
+    assert _coerce_constraint_value("pattern", value) == expected
+
+
+@pytest.mark.parametrize("constraint", ["min_length", "max_length"])
+def test_string_constraints_accept_valid_int_and_str(
+    constraint: ConstraintType,
+) -> None:
+    assert _coerce_constraint_value(constraint, 5) == 5
+    assert _coerce_constraint_value(constraint, "  10  ") == 10
+    assert _coerce_constraint_value(constraint, "-1") == -1
+
+
+@pytest.mark.parametrize("constraint", ["min_length", "max_length"])
+def test_string_constraints_reject_non_numeric_str(constraint: ConstraintType) -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, "abc")
+
+
+@pytest.mark.parametrize("constraint", ["min_length", "max_length"])
+def test_string_constraints_reject_float(constraint: ConstraintType) -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, 1.5)
+
+
+@pytest.mark.parametrize("constraint", ["gt", "ge", "lt", "le", "multiple_of"])
+def test_numeric_constraints_accept_valid(constraint: ConstraintType) -> None:
+    assert _coerce_constraint_value(constraint, 5) == 5
+    assert _coerce_constraint_value(constraint, 2.5) == 2.5
+    assert _coerce_constraint_value(constraint, " -4 ") == -4
+    assert _coerce_constraint_value(constraint, " 0.75 ") == 0.75
+    assert _coerce_constraint_value(constraint, "1e2") == 100.0
+
+
+@pytest.mark.parametrize("constraint", ["gt", "ge", "lt", "le", "multiple_of"])
+def test_numeric_constraints_reject_invalid_str(constraint: ConstraintType) -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, "abc")
+
+
+@pytest.mark.parametrize("constraint", ["min_items", "max_items"])
+def test_collection_constraints_accept_valid(constraint: ConstraintType) -> None:
+    assert _coerce_constraint_value(constraint, 3) == 3
+    assert _coerce_constraint_value(constraint, " 5 ") == 5
+
+
+@pytest.mark.parametrize("constraint", ["min_items", "max_items"])
+def test_collection_constraints_reject_bool(constraint: ConstraintType) -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, True)
+
+
+@pytest.mark.parametrize("constraint", ["min_items", "max_items"])
+def test_collection_constraints_reject_float_and_other(
+    constraint: ConstraintType,
+) -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, 2.5)
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value(constraint, [1, 2])
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("true", True),
+        (" 1 ", True),
+        ("YES", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        (1, True),
+        (0, False),
+        (-5, True),
+        (0.0, False),
+        (0.1, True),
+    ],
+)
+def test_unique_items_coerces_various_types(
+    value: tuple[Any, ...], expected: tuple[Any, ...]
+) -> None:
+    assert _coerce_constraint_value("unique_items", value) is expected
+
+
+def test_unique_items_rejects_unsupported_type() -> None:
+    with pytest.raises(SchemaError):
+        _coerce_constraint_value("unique_items", object())

--- a/tests/test_parsing/test_dataclass_adapter.py
+++ b/tests/test_parsing/test_dataclass_adapter.py
@@ -12,6 +12,7 @@ from conformly._internal.constraints import (
     MinLength,
     OneOf,
 )
+from conformly._internal.constraints.collections import MaxItems, MinItems, UniqueItems
 from conformly._internal.fields import Email
 from conformly._internal.parser import FieldSpec, ModelSpec
 from conformly._internal.parser.adapters.dataclass import (
@@ -79,8 +80,11 @@ class MixedDataclass:
 class ListFieldDataclass:
     text: str
     emails: list[Email]
-    names: list[Annotated[str, MinLength(5), MaxLength(15)]]
+    names: Annotated[
+        list[Annotated[str, MinLength(5), MaxLength(15)]], MinItems(2), MaxItems(10)
+    ]
     model_list: list[DefaultDataclass]
+    unique_list: set[str]
 
 
 class BaseEnum(Enum):
@@ -387,12 +391,13 @@ def test_parse_ignores_initvar_and_classvar() -> None:
 def test_parse_dataclass_with_list_fields() -> None:
     spec = parse(ListFieldDataclass)
 
-    assert len(spec.fields) == 4
+    assert len(spec.fields) == 5
 
     text = spec.fields[0]
     emails = spec.fields[1]
     names = spec.fields[2]
     model_list = spec.fields[3]
+    unique_items = spec.fields[4]
 
     assert text.collection_type is None
     assert emails.field_type is Email
@@ -401,9 +406,13 @@ def test_parse_dataclass_with_list_fields() -> None:
     assert names.field_type is str
     assert names.collection_type is list
     assert len(names.constraints) == 2
+    assert len(names.collection_constraints) == 2
     assert model_list.field_type is DefaultDataclass
     assert model_list.nested_model is not None
     assert model_list.collection_type is list
+    assert unique_items.field_type is str
+    assert unique_items.collection_type is set
+    assert unique_items.collection_constraints == (UniqueItems(True),)
 
 
 # ====== EDGE CASES ======

--- a/tests/test_parsing/test_pydantic_adapter.py
+++ b/tests/test_parsing/test_pydantic_adapter.py
@@ -73,7 +73,9 @@ class ConstrainedModel(BaseModel):
 
 class ListFieldModel(BaseModel):
     emails: list[EmailStr]
-    names: list[Annotated[str, MinLength(5), MaxLength(15)]]
+    names: list[Annotated[str, MinLength(5), MaxLength(15)]] = Field(
+        max_length=10, min_length=1
+    )
     model_list: list[ConstrainedModel]
 
 
@@ -355,6 +357,7 @@ def test_parse_dataclass_with_list_fields() -> None:
     assert names.field_type is str
     assert names.collection_type is list
     assert len(names.constraints) == 2
+    assert len(names.collection_constraints) == 2
     assert model_list.field_type is ConstrainedModel
     assert model_list.nested_model is not None
     assert model_list.collection_type is list

--- a/tests/test_resolver/test_resolve.py
+++ b/tests/test_resolver/test_resolve.py
@@ -10,11 +10,14 @@ from conformly._internal.constraints import (
     GreaterThan,
     LessOrEqual,
     LessThan,
+    MaxItems,
     MaxLength,
+    MinItems,
     MinLength,
     MultipleOf,
     OneOf,
     Pattern,
+    UniqueItems,
 )
 from conformly._internal.fields import SPECIAL_KINDS, Email
 from conformly._internal.parser import FieldSpec, ModelSpec
@@ -588,6 +591,43 @@ def test_resolve_list_with_nested_model(simple_model_spec) -> None:
     assert isinstance(resolved.semantic, ListSemantic)
     assert isinstance(resolved.semantic.element_nested_model, ResolvedModel)
     assert isinstance(resolved.semantic.element_semantic, ObjectSemantic)
+
+
+def test_resolve_constrained_list_type() -> None:
+    field_spec = FieldSpec(
+        name="names",
+        field_type=str,
+        constraints=(MinLength(1), MaxLength(10)),
+        collection_type=list,
+        collection_constraints=(MinItems(10), MaxItems(15), UniqueItems(True)),
+    )
+    path: FieldPath = (1, 2)
+
+    resolved = resolve_field(field_spec, path)
+    semantic = resolved.semantic
+
+    assert isinstance(semantic, ListSemantic)
+    assert isinstance(semantic.element_semantic, StringSemantic)
+    assert semantic.has_constraints is True
+    assert semantic.is_unique_items is True
+    assert semantic.length_range is not None
+    assert semantic.length_range.min_length == 10
+    assert semantic.length_range.max_length == 15
+    assert semantic.element_semantic.length_range.min_length == 1
+    assert semantic.element_semantic.length_range.max_length == 10
+    assert semantic.element_semantic.has_constraints is True
+
+
+def test_resolve_list_invalid_range_raises() -> None:
+    field_spec = FieldSpec(
+        name="names",
+        field_type=str,
+        collection_type=list,
+        collection_constraints=(MinItems(20), MaxItems(15), UniqueItems(True)),
+    )
+
+    with pytest.raises(SchemaError):
+        resolve_field(field_spec, (1,))
 
 
 # ===== TESTS for resolve_model() =====


### PR DESCRIPTION
## Summary

Adds support for collection-level constraints in list generation, including MinItems, MaxItems, and UniqueItems, along with full integration into parsing, resolving, planning, and generation pipeline.

___

## Related issues

Closes #55

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [x] resolver
- [x] planner
- [x] generators
- [x] constraints
- [x] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [ ] ci

---

## Breking changes

- [ ] Yes
- [x] No

---

## Tests

- [x] Unit tests added
- [x] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [x] CHANGELOG updated
- [x] README updated (if needed)
- [ ] Version increased (if needed)
