### PR TITLE
feat: cross-adapter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - Planned
+
+### Added
+- **Cross-adapter parsign** - now parser uses adapters registry for nested models, so schemas like `dataclass` inside `pydantic.BaseModel` supported
 
 ## [0.4.0] - 2025.05.09
 

--- a/src/conformly/_internal/parser/adapters/dataclass.py
+++ b/src/conformly/_internal/parser/adapters/dataclass.py
@@ -57,8 +57,6 @@ def parse_field(field: Field[Any], field_type: Any) -> FieldSpec:
             field_name=field_name,
             extra_constraints=constraints,
             resolve_type=lambda x: x,
-            parse_model=parse,
-            supports_model=supports,
         ),
     )
 

--- a/src/conformly/_internal/parser/adapters/pydantic.py
+++ b/src/conformly/_internal/parser/adapters/pydantic.py
@@ -79,8 +79,6 @@ def parse_field(
             field_name=field_name,
             extra_constraints=constraints,
             resolve_type=_resolve_pydantic_special_type,
-            parse_model=parse,
-            supports_model=supports,
         ),
     )
 

--- a/src/conformly/_internal/parser/adapters/registry.py
+++ b/src/conformly/_internal/parser/adapters/registry.py
@@ -21,3 +21,10 @@ def get_adapter(model: type) -> ParcingAdapterProtocol:
             "registred_adapters": [type(a).__name__ for a in _adapters],
         },
     )
+
+
+def get_adapter_or_none(model: type) -> ParcingAdapterProtocol | None:
+    for adapter in _adapters:
+        if adapter.supports(model):
+            return adapter
+    return None

--- a/src/conformly/_internal/parser/core/element.py
+++ b/src/conformly/_internal/parser/core/element.py
@@ -1,9 +1,10 @@
 from collections.abc import Callable
 from typing import Any
 
+from ..adapters.registry import get_adapter_or_none
 from ..extractors.constraints import is_constraints_consistent
 from ..extractors.types import TypeNode
-from ..models import ElementSpec, ModelSpec
+from ..models import ElementSpec
 
 from conformly._internal.constraints import Constraint
 from conformly._internal.types.constants import ENUMERATED_TYPE
@@ -16,8 +17,6 @@ def build_element_spec(
     field_name: str,
     extra_constraints: tuple[Constraint, ...],
     resolve_type: Callable[[Any], Any],
-    parse_model: Callable[[type], ModelSpec],
-    supports_model: Callable[[type], bool],
 ) -> ElementSpec:
     runtime_type = resolve_type(node.runtime_type)
 
@@ -34,10 +33,12 @@ def build_element_spec(
             },
         )
 
+    adapter = get_adapter_or_none(runtime_type)
+
     nested_model = (
-        parse_model(runtime_type)
-        if runtime_type is not ENUMERATED_TYPE and supports_model(runtime_type)
-        else None
+        None
+        if runtime_type is ENUMERATED_TYPE or adapter is None
+        else adapter.parse(runtime_type)
     )
 
     return ElementSpec(

--- a/tests/test_parsing/test_cross_adapter_parsing.py
+++ b/tests/test_parsing/test_cross_adapter_parsing.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("pydantic", reason="Pydantic adapter requires 'pydantic' package")
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from conformly._internal.parser import parse_model
+
+
+@dataclass
+class Address:
+    city: str
+    street: str
+
+
+class User(BaseModel):
+    name: str
+    address: Address
+
+
+def test_parse_dataclass_in_pydantic_model() -> None:
+    spec = parse_model(User)
+
+    assert len(spec.fields) == 2
+    assert spec.fields[1].element is not None
+    assert spec.fields[1].element.nested_model is not None
+    assert len(spec.fields[1].element.nested_model.fields) == 2


### PR DESCRIPTION
## Summary

Now parser uses adapters registry for nested models, so schemas like `dataclass` inside `pydantic.BaseModel` supported

___

## Related issues

Closes #75 

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [ ] resolver
- [ ] planner
- [ ] generators
- [ ] constraints
- [x] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [ ] ci


## Breking changes

- [ ] Yes
- [x] No

---

## Tests

- [x] Unit tests added
- [ ] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [x] CHANGELOG updated
- [ ] README updated (if needed)
- [ ] Version increased (if needed)
