### PR TITLE
feat: add TypedDict adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Cross-adapter parsign** - now parser uses adapters registry for nested models, so schemas like `dataclass` inside `pydantic.BaseModel` supported
+- **TypedDict adapter** - support for parsing `TypedDict` schemas, including required/optional fields via `NotRequired` / `Required`
+
 
 ## [0.4.0] - 2025.05.09
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
 
-**Declarative test data generator for Python. Turns data models (dataclasses, Pydantic) and type constraints into valid fixtures and negative test cases.**
+**Declarative test data generator for Python. Turns data models (dataclasses, Pydantic, TypedDict) and type constraints into valid fixtures and negative test cases.**
 Define constraints once in type annotations — generate both valid and minimal invalid test data automatically.
 No factories, no hardcoded fixtures, no drift when schema changes.
 
@@ -24,6 +24,8 @@ No factories, no hardcoded fixtures, no drift when schema changes.
 - [Quickstart](#quickstart)
   - [With dataclasses](#with-dataclasses)
   - [With Pydantic](#with-pydantic)
+  - [With TypedDict](#with-typeddict)
+  - [With Mixed Models](#with-mixed-models)
 - [API Reference](#api-reference)
 - [Error Handling](#error-handling)
 - [Invalid Generation Contract](#invalid-generation-contract)
@@ -47,6 +49,8 @@ No factories, no hardcoded fixtures, no drift when schema changes.
 - **Schema as single source of truth** - change a constraint → all test data adapts automatically
 - **Unified constraint model** - multiple declaration styles normalized internaly
 - **Framework adapters** - dataclasses (built-in), Pydantic (optional via `conformly[pydantic]`)
+- **Cross-adapter nesting** - freely combine schemas across frameworks (e.g. `TypedDict` inside `dataclass`, `dataclass` inside `Pydantic`)
+
 
 ## Install
 
@@ -92,6 +96,47 @@ class User(BaseModel):
 
 valid = case(User, valid=True)
 # -> {"username": "Abc", "email": "x@y.z", "age": 42}
+```
+
+### With TypedDict
+
+```python
+from typing import Annotated, TypedDict
+from conformly import case, MinLength, Pattern, GreaterOrEqual, LessOrEqual
+
+
+class User(TypedDict):
+    username: Annotated[str, MinLength(3)]
+    email: Annotated[str, Pattern(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")]
+    age: Annotated[int, GreaterOrEqual(18), LessOrEqual(120)]
+
+valid = case(User, valid=True)
+# -> {"username": "Abc", "email": "x@y.z", "age": 42}
+```
+
+### With Mixed Models
+
+```python
+from dataclasses import dataclass
+from typing import TypedDict
+from pydantic import BaseModel
+
+
+class Meta(TypedDict):
+    version: int
+
+
+@dataclass
+class Profile:
+    meta: Meta
+
+
+class User(BaseModel):
+    profile: Profile
+
+
+valid = case(User, valid=True)
+# -> {"profile": {"meta": {"version": 1}}}
 ```
 
 ## API Reference

--- a/src/conformly/_internal/parser/adapters/bootstrap.py
+++ b/src/conformly/_internal/parser/adapters/bootstrap.py
@@ -1,8 +1,9 @@
 def register_builtin_adapters() -> None:
-    from . import dataclass
+    from . import dataclass, typeddict
     from .registry import register
 
     register(dataclass)
+    register(typeddict)
 
     try:
         from . import pydantic

--- a/src/conformly/_internal/parser/adapters/typeddict.py
+++ b/src/conformly/_internal/parser/adapters/typeddict.py
@@ -1,0 +1,61 @@
+from functools import lru_cache
+from typing import Any, get_type_hints, is_typeddict
+
+from ..core import build_element_spec, build_field_spec
+from ..models import FieldSpec, ModelSpec
+
+from conformly._internal.types.constants import UNSET
+from conformly.exceptions import ResolutionError
+
+
+def supports(model: type) -> bool:
+    return is_typeddict(model)
+
+
+@lru_cache(maxsize=128)
+def parse(model: type) -> ModelSpec:
+    if not supports(model):
+        raise ResolutionError(
+            f"Unsupported model type: {model}",
+            context={
+                "code": "unsupported_model_type",
+                "model": repr(model),
+                "expected": "TypedDict",
+            },
+        )
+
+    return ModelSpec(name=model.__name__, type="typeddict", fields=parse_fields(model))
+
+
+def parse_fields(model: type) -> tuple[FieldSpec, ...]:
+    type_hints = get_type_hints(model, include_extras=True)
+
+    required = getattr(model, "__required_keys__", set(type_hints.keys()))
+
+    return tuple(
+        parse_field(
+            name=name,
+            field_type=resolve_type(type_hints, name),
+            required=name in required,
+        )
+        for name in type_hints
+    )
+
+
+def resolve_type(type_hints: dict[str, Any], field_name: str) -> Any:
+    return type_hints[field_name]
+
+
+def parse_field(name: str, field_type: Any, required: bool) -> FieldSpec:
+    return build_field_spec(
+        name=name,
+        field_type=field_type,
+        default=UNSET if required else None,
+        external_constraints=(),
+        resolve_element=lambda node, field_name, constraints: build_element_spec(
+            node=node,
+            field_name=field_name,
+            extra_constraints=constraints,
+            resolve_type=lambda x: x,
+        ),
+    )

--- a/src/conformly/_internal/parser/adapters/typeddict.py
+++ b/src/conformly/_internal/parser/adapters/typeddict.py
@@ -1,5 +1,13 @@
 from functools import lru_cache
-from typing import Any, get_type_hints, is_typeddict
+from typing import (
+    Any,
+    NotRequired,
+    Required,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
 
 from ..core import build_element_spec, build_field_spec
 from ..models import FieldSpec, ModelSpec
@@ -9,6 +17,7 @@ from conformly.exceptions import ResolutionError
 
 
 def supports(model: type) -> bool:
+    print(is_typeddict(model))
     return is_typeddict(model)
 
 
@@ -43,7 +52,14 @@ def parse_fields(model: type) -> tuple[FieldSpec, ...]:
 
 
 def resolve_type(type_hints: dict[str, Any], field_name: str) -> Any:
-    return type_hints[field_name]
+    t = type_hints[field_name]
+
+    origin = get_origin(t)
+
+    if origin is NotRequired or origin is Required:
+        return get_args(t)[0]
+
+    return t
 
 
 def parse_field(name: str, field_type: Any, required: bool) -> FieldSpec:

--- a/src/conformly/_internal/parser/core/element.py
+++ b/src/conformly/_internal/parser/core/element.py
@@ -20,6 +20,8 @@ def build_element_spec(
 ) -> ElementSpec:
     runtime_type = resolve_type(node.runtime_type)
 
+    print(runtime_type)
+
     all_constraints = (*node.constraints, *extra_constraints)
 
     if not is_constraints_consistent(all_constraints):

--- a/src/conformly/_internal/parser/models.py
+++ b/src/conformly/_internal/parser/models.py
@@ -52,7 +52,7 @@ class FieldSpec:
         )
 
 
-ModelType = Literal["dataclass", "pydantic"]
+ModelType = Literal["dataclass", "pydantic", "typeddict"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_parsing/test_cross_adapter_parsing.py
+++ b/tests/test_parsing/test_cross_adapter_parsing.py
@@ -3,6 +3,7 @@ import pytest
 pytest.importorskip("pydantic", reason="Pydantic adapter requires 'pydantic' package")
 
 from dataclasses import dataclass
+from typing import NotRequired, TypedDict
 
 from pydantic import BaseModel
 
@@ -24,6 +25,108 @@ def test_parse_dataclass_in_pydantic_model() -> None:
     spec = parse_model(User)
 
     assert len(spec.fields) == 2
-    assert spec.fields[1].element is not None
-    assert spec.fields[1].element.nested_model is not None
-    assert len(spec.fields[1].element.nested_model.fields) == 2
+
+    address_field = next(f for f in spec.fields if f.name == "address")
+
+    assert address_field.element is not None
+    assert address_field.element.nested_model is not None
+    assert len(address_field.element.nested_model.fields) == 2
+
+
+class AddressTD(TypedDict):
+    city: str
+    street: str
+
+
+class UserWithTD(BaseModel):
+    name: str
+    address: AddressTD
+
+
+def test_parse_typeddict_in_pydantic_model() -> None:
+    spec = parse_model(UserWithTD)
+
+    address_field = next(f for f in spec.fields if f.name == "address")
+
+    assert address_field.element is not None
+    nested = address_field.element.nested_model
+
+    assert nested is not None
+    assert nested.type == "typeddict"
+    assert {f.name for f in nested.fields} == {"city", "street"}
+
+
+class AddressOptionalTD(TypedDict):
+    city: str
+    street: NotRequired[str]
+
+
+class UserWithOptionalTD(BaseModel):
+    address: AddressOptionalTD
+
+
+def test_parse_typeddict_optional_field() -> None:
+    spec = parse_model(UserWithOptionalTD)
+
+    assert spec.fields[0].element is not None
+    assert spec.fields[0].element.nested_model is not None
+    nested = spec.fields[0].element.nested_model
+    fields = {f.name: f for f in nested.fields}
+
+    assert fields["city"].default is not None or True
+    assert fields["street"].default is None
+
+
+class InnerModel(BaseModel):
+    x: int
+    y: int
+
+
+class OuterModel(BaseModel):
+    inner: InnerModel
+
+
+def test_parse_nested_pydantic_model() -> None:
+    spec = parse_model(OuterModel)
+
+    inner_field = spec.fields[0]
+
+    assert inner_field.element is not None
+    nested = inner_field.element.nested_model
+
+    assert nested is not None
+    assert nested.name == "InnerModel"
+    assert len(nested.fields) == 2
+
+
+class MetaTD(TypedDict):
+    version: int
+
+
+@dataclass
+class Profile:
+    meta: MetaTD
+
+
+class ComplexUser(BaseModel):
+    profile: Profile
+
+
+def test_parse_deep_mixed_nesting() -> None:
+    spec = parse_model(ComplexUser)
+
+    assert spec.fields[0].element is not None
+    assert spec.fields[0].element.nested_model is not None
+
+    profile_model = spec.fields[0].element.nested_model
+
+    assert profile_model is not None
+
+    assert profile_model.fields[0].element is not None
+    assert profile_model.fields[0].element.nested_model is not None
+
+    meta_model = profile_model.fields[0].element.nested_model
+
+    assert meta_model is not None
+    assert meta_model.type == "typeddict"
+    assert {f.name for f in meta_model.fields} == {"version"}

--- a/tests/test_parsing/test_typeddict_adapter.py
+++ b/tests/test_parsing/test_typeddict_adapter.py
@@ -1,0 +1,95 @@
+from typing import NotRequired, TypedDict
+
+import pytest
+
+from conformly._internal.parser.adapters.typeddict import (
+    parse,
+    parse_fields,
+    resolve_type,
+    supports,
+)
+from conformly._internal.types.constants import UNSET
+from conformly.exceptions import ResolutionError
+
+
+class User(TypedDict):
+    id: int
+    name: str
+
+
+class PartialUser(TypedDict):
+    id: int
+    name: NotRequired[str]
+
+
+class NotATypedDict:
+    x: int
+
+
+# ====== TESTS FOR supports() ======
+
+
+def test_supports_typeddict():
+    assert supports(User) is True
+
+
+def test_supports_non_typeddict():
+    assert supports(NotATypedDict) is False
+
+
+# ====== TESTS FOR supports() ======
+
+
+def test_parse_typeddict_basic():
+    spec = parse(User)
+
+    assert spec.name == "User"
+    assert spec.type == "typeddict"
+    assert len(spec.fields) == 2
+
+    field_names = {f.name for f in spec.fields}
+    assert field_names == {"id", "name"}
+
+
+def test_parse_raises_on_invalid_model():
+    with pytest.raises(ResolutionError) as e:
+        parse(NotATypedDict)
+
+    assert e.value.context["code"] == "unsupported_model_type"
+
+
+# ====== TESTS FOR parse_fields() ======
+
+
+def test_parse_fields_required():
+    fields = parse_fields(User)
+
+    defaults = {f.name: f.default for f in fields}
+
+    assert defaults["id"] is UNSET
+    assert defaults["name"] is UNSET
+
+
+def test_parse_fields_optional():
+    fields = parse_fields(PartialUser)
+
+    defaults = {f.name: f.default for f in fields}
+
+    assert defaults["id"] is UNSET
+    assert defaults["name"] is None
+
+
+# ====== EXTRA TESTS ======
+
+
+def test_resolve_type_returns_correct_type():
+    hints = {"id": int}
+
+    assert resolve_type(hints, "id") is int
+
+
+def test_parse_is_cached():
+    spec1 = parse(User)
+    spec2 = parse(User)
+
+    assert spec1 is spec2


### PR DESCRIPTION
## Summary

Add and register `TypedDict` parsing adapter.

___

## Related issues

Closes #76 

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [ ] resolver
- [ ] planner
- [ ] generators
- [ ] constraints
- [x] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [ ] ci

---

## Breking changes

- [ ] Yes
- [x] No

If yes, update documentation, describe change and required migration steps.

---

## Tests

- [x] Unit tests added
- [x] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [x] CHANGELOG updated
- [x] README updated (if needed)
- [ ] Version increased (if needed)
