### PR TITLE
feat: basic attrs adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,10 +57,37 @@ jobs:
             config: core
             extras: ""
             collect-coverage: false
+          - python-version: "3.14"
+            config: core
+            extras: ""
+            collect-coverage: true
+
+          - python-version: "3.12"
+            config: pydantic
+            extras: "pydantic"
+            collect-coverage: false
           - python-version: "3.13"
             config: pydantic
             extras: "pydantic"
+            collect-coverage: false
+          - python-version: "3.14"
+            config: pydantic
+            extras: "pydantic"
             collect-coverage: true
+
+          - python-version: "3.12"
+            config: attrs
+            extras: "attrs"
+            collect-coverage: false
+          - python-version: "3.13"
+            config: attrs
+            extras: "attrs"
+            collect-coverage: false
+          - python-version: "3.14"
+            config: attrs
+            extras: "attrs"
+            collect-coverage: true
+
     name: Test (${{ matrix.config }}, py${{ matrix.python-version }})
     steps:
       - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: mypy
         files: ^src/conformly/
         args: [--config-file=pyproject.toml]
-        additional_dependencies: [rstr, pydantic]
+        additional_dependencies: [rstr, pydantic, attrs]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Planned
+## [0.5.0] - 2026.06.10
 
 ### Added
-- **Cross-adapter parsign** - now parser uses adapters registry for nested models, so schemas like `dataclass` inside `pydantic.BaseModel` supported
+- **Basic `attrs` adapter** - support for attrs models as source for generation *(Note: native `attrs` validators are not yet supported and will be added later)*
+- **Cross-adapter parsing** - now parser uses adapters registry for nested models, so schemas like `dataclass` inside `pydantic.BaseModel` supported
 - **TypedDict adapter** - support for parsing `TypedDict` schemas, including required/optional fields via `NotRequired` / `Required`
 
 
-## [0.4.0] - 2025.05.09
+## [0.4.0] - 2026.05.09
 
 ### Added
 - **Unified exception hierarchy** — all library errors now inherit from `ConformlyError`, providing consistent interface for error handling and logging.
@@ -41,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `ElementSpec` for standardized type representation.
 
 
-## [0.3.10] - 2025.04.11
+## [0.3.10] - 2026.04.11
 
 ### Added
 - **Full support for `multiple_of` constraint**. Added `MultipleOf` constraint in conformly-style semantics and `Field(multiple_of=...)` support for Pydantic models. Values are now generated respecting the step, including invalid value generation (`NOT_MULTIPLE` violation).
@@ -60,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Hide internal logic** in `_internal` module.
 
 
-## [0.3.9] - 2025.03.21
+## [0.3.9] - 2026.03.21
 
 ### Added
 - **Deterministic generation** new `seed: int | None = None` parameter in `case()` and `cases()` for reproducible test data
@@ -71,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Internal architecture** - all generators now receive `GenerationContext` instead of raw `rng`
 
 
-## [0.3.8] - 2025.03.09
+## [0.3.8] - 2026.03.09
 
 ### Added
 - **all_violations** srategy - generates case for every allowed violations including constraints, structural and type violations (ignores count)
@@ -85,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ViolationType enum** now uses string values instead of auto()
 
 
-## [0.3.7] - 2025.03.03
+## [0.3.7] - 2026.03.03
 
 ### Added
 - **Internal benchmarking infrastructure** for dataclasses and pydantic models (Makefile, pytest marks), benchmark tests
@@ -96,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Optimized generate_invalid** logic by splitting loops, removing tuple allocations, and simplifying recursion
 - **`ResolvedField` refactor** to store `FieldSpec` directly instead of copying values
 
-## [0.3.6] - 2025.02.18
+## [0.3.6] - 2026.02.18
 
 ### Added
 - **`allow_structural_violations` flag for `cases()`** API to abable field missing and extra fields for invalid generation
@@ -104,7 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`MISSING_FIELD`** available for every field like `TYPE_MISMATCH`
 - **`EXTRA_FIELD`** adds only one time for model/nested model
 
-## [0.3.5] - 2025.02.15
+## [0.3.5] - 2026.02.15
 
 ### Added
 - **`allow_type_mismatch` flag for `case()` and `cases()`** APIs to enable type mismatch violations (e.g., string instead of int) when generating invalid examples
@@ -115,7 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `bool` and `object` fields can now be violated via type mismatches when `allow_type_mismatch=True`; `NotImplementedError` is raised only when attempting to violate these types with `allow_type_mismatch=False` (no semantic constraints available)
 
-## [0.3.4] - 2025.02.09
+## [0.3.4] - 2026.02.09
 
 ### Added
 - **Pydantic parsing adapter** as optional adapter (availiable only with `pip install conformly[pydantic]`)
@@ -132,7 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Known Limitations
 - `default_factory` support not yet implemented for dataclass/Pydantic fields
 
-## [0.3.3] - 2025.02.01
+## [0.3.3] - 2026.02.01
 
 ### Added
 - **Full support for closed-set types** (`Literal` from `typing` and classical `Enum`)
@@ -148,14 +149,14 @@ but can be used as part of real model)
 Combinig `Literal`/`Enum` with other constraints results in a parsing error.
 
 
-## [0.3.2] - 2025.01.29
+## [0.3.2] - 2026.01.29
 
 ### Changed
 - Refactored internal collections to use `tuple` instead of `list` for
   immutable data structures. **No changes to public API or runtime behavior**.
 
 
-## [0.3.1] - 2025-01-28
+## [0.3.1] - 2026-01-28
 
 ### Added
 - Semantic relover  (`ModelSpec -> ResolvedModel`)
@@ -176,7 +177,7 @@ Combinig `Literal`/`Enum` with other constraints results in a parsing error.
 
 
 
-## [0.3.0] - 2025-01-21
+## [0.3.0] - 2026-01-21
 
 ### Added
 - Support for **nested_models** (tree structures) in parsing and generation

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ No factories, no hardcoded fixtures, no drift when schema changes.
   - [With dataclasses](#with-dataclasses)
   - [With Pydantic](#with-pydantic)
   - [With TypedDict](#with-typeddict)
+  - [With Attrs](#with-attrs)
   - [With Mixed Models](#with-mixed-models)
 - [API Reference](#api-reference)
 - [Error Handling](#error-handling)
@@ -113,6 +114,27 @@ class User(TypedDict):
 valid = case(User, valid=True)
 # -> {"username": "Abc", "email": "x@y.z", "age": 42}
 ```
+
+### With Attrs
+
+```python
+import attrs
+from typing import Annotated
+from conformly import case, MinLength, Pattern, GreaterOrEqual, LessOrEqual
+
+
+@attrs.define
+class User:
+    username: Annotated[str, MinLength(3)]
+    email: Annotated[str, Pattern(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")]
+    age: Annotated[int, GreaterOrEqual(18), LessOrEqual(120)]
+
+valid = case(User, valid=True)
+# -> {"username": "Abc", "email": "x@y.z", "age": 42}
+```
+
+> Note: Native attrs validators are not yet supported. To define constraints for attrs models, please use `typing.Annotated` with conformly constraints as shown in the example above. Support for native attrs validators will be added later
+
 
 ### With Mixed Models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ version = "0.4.0"
 description = "Generate valid & invalid test data from your typed schemas"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "rstr>=3.2.2",
-]
+dependencies = ["rstr>=3.2.2"]
 license = {text = "MIT"}
 authors = [{name = "Nikita Shabanov", email = "nik.shabanov2024@gmail.com"}]
 keywords = ["testing", "fixtures", "test-data", "dataclasses", "validation"]
@@ -27,6 +25,8 @@ Issues = "https://github.com/nashabanov/conformly/issues"
 
 [project.optional-dependencies]
 pydantic = ["pydantic>=2.0.0,<3.0.0", "email-validator>=2.0.0"]
+attrs = ["attrs>=23.0.0"]
+all = ["pydantic>=2.0.0,<3.0.0", "email-validator>=2.0.0", "attrs>=23.0.0"]
 
 [dependency-groups]
 dev = [

--- a/src/conformly/_internal/parser/adapters/attrs.py
+++ b/src/conformly/_internal/parser/adapters/attrs.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from ..models import ModelSpec
+
+from conformly.exceptions import ResolutionError
+
+
+def supports(model: type) -> bool:
+    return hasattr(model, "__attrs_attrs__")
+
+
+@lru_cache(maxsize=128)
+def parse(model: type) -> ModelSpec:
+    try:
+        import attrs
+    except ImportError:
+        raise ImportError(
+            "Attrs adapter requires 'attrs' package. "
+            "Install with: pip install 'conformly[attrs]'"
+        ) from None
+
+    if not attrs.has(model):
+        raise ResolutionError(
+            f"Unsupported model type: {model}",
+            context={
+                "code": "unsupported_model_type",
+                "model": repr(model),
+                "expected": "attrs class",
+            },
+        )
+
+    return ModelSpec(name=model.__name__, type="attrs", fields=())

--- a/src/conformly/_internal/parser/adapters/attrs.py
+++ b/src/conformly/_internal/parser/adapters/attrs.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import TYPE_CHECKING, Any, get_type_hints
 
-from ..models import ModelSpec
+from ..core import build_element_spec, build_field_spec
+from ..models import FieldSpec, ModelSpec
 
+from conformly._internal.types.constants import UNSET
 from conformly.exceptions import ResolutionError
+
+if TYPE_CHECKING:
+    from attrs import Attribute
 
 
 def supports(model: type) -> bool:
@@ -31,4 +37,51 @@ def parse(model: type) -> ModelSpec:
             },
         )
 
-    return ModelSpec(name=model.__name__, type="attrs", fields=())
+    return ModelSpec(
+        name=model.__name__,
+        type="attrs",
+        fields=parse_fields(model),
+    )
+
+
+def parse_fields(model: type) -> tuple[FieldSpec, ...]:
+    import attrs
+
+    type_hints = get_type_hints(model, include_extras=True)
+
+    attrs_fields = attrs.fields(model)
+
+    return tuple(
+        parse_field(attr, resolve_type(type_hints, attr.name)) for attr in attrs_fields
+    )
+
+
+def resolve_type(type_hints: dict[str, Any], field_name: str) -> Any:
+    return type_hints[field_name]
+
+
+def parse_field(attr: Attribute[Any], field_type: Any) -> FieldSpec:
+    return build_field_spec(
+        name=attr.name,
+        field_type=field_type,
+        default=parse_defaults(attr),
+        external_constraints=(),
+        resolve_element=lambda node, field_name, constraints: build_element_spec(
+            node=node,
+            field_name=field_name,
+            extra_constraints=constraints,
+            resolve_type=lambda x: x,
+        ),
+    )
+
+
+def parse_defaults(attr: Any) -> Any:
+    import attrs
+
+    if attr.default is attrs.NOTHING:
+        return UNSET
+
+    if type(attr.default).__name__ == "Factory":
+        return attr.default
+
+    return attr.default

--- a/src/conformly/_internal/parser/adapters/bootstrap.py
+++ b/src/conformly/_internal/parser/adapters/bootstrap.py
@@ -8,6 +8,13 @@ def register_builtin_adapters() -> None:
     try:
         from . import pydantic
     except ImportError:
-        return
+        pass
+    else:
+        register(pydantic)
 
-    register(pydantic)
+    try:
+        from . import attrs
+    except ImportError:
+        pass
+    else:
+        register(attrs)

--- a/src/conformly/_internal/parser/models.py
+++ b/src/conformly/_internal/parser/models.py
@@ -52,7 +52,7 @@ class FieldSpec:
         )
 
 
-ModelType = Literal["dataclass", "pydantic", "typeddict"]
+ModelType = Literal["dataclass", "pydantic", "typeddict", "attrs"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_parsing/test_attrs_adapter.py
+++ b/tests/test_parsing/test_attrs_adapter.py
@@ -1,0 +1,39 @@
+import pytest
+
+pytest.importorskip("attrs", reason="attrs adapter requires 'attrs' package")
+pytest.importorskip("attr", reason="attrs adapter requires 'attrs' package")
+
+import attrs
+
+from conformly._internal.parser.adapters.attrs import supports
+
+
+@attrs.define
+class DummyAttrs:
+    x: int
+
+
+class NotAttrs:
+    pass
+
+
+def test_supports_attrs() -> None:
+    assert supports(DummyAttrs)
+
+
+def test_supports_not_attrs() -> None:
+    assert not supports(NotAttrs)
+
+
+def test_supports_int() -> None:
+    assert not supports(int)
+
+
+def test_supports_legacy_attrs() -> None:
+    import attr
+
+    @attr.s
+    class LegacyAttrs:
+        x: int
+
+    assert supports(LegacyAttrs)

--- a/tests/test_parsing/test_attrs_adapter.py
+++ b/tests/test_parsing/test_attrs_adapter.py
@@ -1,20 +1,108 @@
 import pytest
 
 pytest.importorskip("attrs", reason="attrs adapter requires 'attrs' package")
-pytest.importorskip("attr", reason="attrs adapter requires 'attrs' package")
+
+from enum import Enum
+from typing import Annotated, Any, Literal
 
 import attrs
 
-from conformly._internal.parser.adapters.attrs import supports
+from conformly._internal.constraints import (
+    GreaterOrEqual,
+    LessOrEqual,
+    MaxLength,
+    MinLength,
+    OneOf,
+)
+from conformly._internal.constraints.collections import MaxItems, MinItems, UniqueItems
+from conformly._internal.fields import Email
+from conformly._internal.parser import FieldSpec, ModelSpec
+from conformly._internal.parser.adapters.attrs import (
+    parse,
+    parse_defaults,
+    parse_field,
+    parse_fields,
+    resolve_type,
+    supports,
+)
+from conformly._internal.types import ENUMERATED_TYPE, UNSET
+from conformly.exceptions import ResolutionError
+
+# ====== FIXTURES & MODELS ======
+
+
+class NotAttrs:
+    pass
 
 
 @attrs.define
 class DummyAttrs:
     x: int
+    y: str
 
 
-class NotAttrs:
-    pass
+@attrs.define
+class DefaultAttrs:
+    name: str = attrs.field(default="John")
+    items: list = attrs.field(factory=list)
+
+
+@attrs.define
+class OptionalAttrs:
+    email: str | None = None
+    nickname: int | None = None
+
+
+class RoleTypeEnum(Enum):
+    admin = 0
+    guest = 1
+    user = 2
+
+
+@attrs.define
+class EnumeratedAttrs:
+    role: Literal["admin", "guest", "user"]
+    role_type: RoleTypeEnum
+
+
+@attrs.define
+class ConstraintsAttrs:
+    # Constraints только через Annotated, как указано в требованиях
+    age: Annotated[int, "ge=0", "le=150"]
+    email: Annotated[str, "pattern=^\\w+@\\w+\\.\\w+$"]
+    tags: Annotated[list[str], MinItems(1), MaxItems(10)]
+
+
+@attrs.define
+class MixedAttrs:
+    id: int
+    name: str = "default"
+    email: str | None = None
+    age: Annotated[int, "ge=0", "le=150"] = 18
+
+
+@attrs.define
+class ListFieldAttrs:
+    text: str
+    emails: list[Email]
+    names: Annotated[
+        list[Annotated[str, MinLength(5), MaxLength(15)]], MinItems(2), MaxItems(10)
+    ]
+    model_list: list[DefaultAttrs]
+    unique_list: set[str]
+
+
+@attrs.define
+class DictFieldAttrs:
+    text: str
+    emails: dict[str, Email]
+    model_dict: dict[str, DefaultAttrs]
+    annotated_dict: Annotated[
+        dict[Annotated[str, MinLength(5)], Annotated[str, MaxLength(10)]], MinItems(4)
+    ]
+
+
+# ====== TESTS FOR supports() ======
 
 
 def test_supports_attrs() -> None:
@@ -37,3 +125,433 @@ def test_supports_legacy_attrs() -> None:
         x: int
 
     assert supports(LegacyAttrs)
+
+
+# ====== TESTS FOR resolve_type() ======
+
+
+def test_resolve_type_simple() -> None:
+    type_hints = {"x": int}
+    assert resolve_type(type_hints, "x") is int
+
+
+def test_resolve_type_optional() -> None:
+    type_hints = {"email": str | None}
+    assert resolve_type(type_hints, "email") == str | None
+
+
+def test_resolve_type_annotated() -> None:
+    type_hints = {"age": Annotated[int, "ge=0", "le=150"]}
+    field_type = resolve_type(type_hints, "age")
+    assert field_type == Annotated[int, "ge=0", "le=150"]
+
+
+# ====== TESTS FOR parse_defaults() ======
+
+
+def test_parse_default_simple() -> None:
+    fields = attrs.fields(DefaultAttrs)
+    default = parse_defaults(fields[0])
+    assert default == "John"
+
+
+def test_parse_default_factory() -> None:
+    fields = attrs.fields(DefaultAttrs)
+    default = parse_defaults(fields[1])
+    assert default.factory is list
+
+
+def test_parse_default_factory_creates_new() -> None:
+    fields = attrs.fields(DefaultAttrs)
+    factory_obj = parse_defaults(fields[1])
+    first = factory_obj.factory()
+    second = factory_obj.factory()
+    assert first is not second
+    assert first == second
+
+
+def test_parse_default_missing() -> None:
+    fields = attrs.fields(DummyAttrs)
+    default = parse_defaults(fields[0])
+    assert default == UNSET
+
+
+def test_parse_default_none() -> None:
+    fields = attrs.fields(OptionalAttrs)
+    default = parse_defaults(fields[0])
+    assert default is None
+    assert default is not UNSET
+
+
+def test_parse_default_zero() -> None:
+    @attrs.define
+    class ZeroDefault:
+        count: int = 0
+
+    default = parse_defaults(attrs.fields(ZeroDefault)[0])
+    assert default == 0
+    assert default is not UNSET
+
+
+def test_parse_default_empty_string() -> None:
+    @attrs.define
+    class EmptyStringDefault:
+        text: str = ""
+
+    default = parse_defaults(attrs.fields(EmptyStringDefault)[0])
+    assert default == ""
+    assert default is not UNSET
+
+
+def test_parse_default_factory_exception() -> None:
+    def bad_factory() -> None:
+        raise RuntimeError("should not be called during parsing")
+
+    @attrs.define
+    class BadFactory:
+        x: Any = attrs.field(factory=bad_factory)
+
+    default = parse_defaults(attrs.fields(BadFactory)[0])
+    assert default.factory is bad_factory
+
+
+# ====== TESTS FOR parse_field() ======
+
+
+def test_parse_field_simple() -> None:
+    f = attrs.fields(DummyAttrs)[0]
+    field_spec = parse_field(f, int)
+    assert isinstance(field_spec, FieldSpec)
+    assert field_spec.name == "x"
+    assert field_spec.element is not None
+    assert field_spec.element.field_type is int
+
+
+def test_parse_field_with_default() -> None:
+    f = attrs.fields(DefaultAttrs)[0]
+    field_spec = parse_field(f, str)
+    assert field_spec.default == "John"
+
+
+def test_parse_field_with_constraints() -> None:
+    f = attrs.fields(ConstraintsAttrs)[0]
+    field_type = Annotated[int, "ge=0", "le=150"]
+    field_spec = parse_field(f, field_type)
+    assert field_spec.element is not None
+    assert len(field_spec.element.constraints) > 0
+
+
+def test_parse_field_nullable() -> None:
+    f = attrs.fields(OptionalAttrs)[0]
+    field_type = str | None
+    field_spec = parse_field(f, field_type)
+    assert field_spec.nullable is True
+
+
+def test_parse_field_not_nullable() -> None:
+    f = attrs.fields(DummyAttrs)[0]
+    field_spec = parse_field(f, int)
+    assert field_spec.nullable is False
+
+
+def test_parse_field_has_default_method() -> None:
+    f1 = attrs.fields(DefaultAttrs)[0]
+    fs1 = parse_field(f1, str)
+    assert fs1.has_default() is True
+
+    f2 = attrs.fields(DummyAttrs)[0]
+    fs2 = parse_field(f2, int)
+    assert fs2.has_default() is False
+
+
+def test_parse_field_literal() -> None:
+    f = attrs.fields(EnumeratedAttrs)[0]
+    field_spec = parse_field(f, Literal["admin", "guest", "user"])
+    assert field_spec.element is not None
+    assert field_spec.element.field_type is ENUMERATED_TYPE
+    assert len(field_spec.element.constraints) == 1
+    assert field_spec.element.constraints[0] == OneOf(("admin", "guest", "user"))
+
+
+def test_parse_field_enum() -> None:
+    f = attrs.fields(EnumeratedAttrs)[1]
+    field_spec = parse_field(f, RoleTypeEnum)
+    assert field_spec.element is not None
+    assert field_spec.element.field_type is ENUMERATED_TYPE
+    assert len(field_spec.element.constraints) == 1
+    assert field_spec.element.constraints[0] == OneOf((0, 1, 2))
+
+
+# ====== TESTS FOR parse_fields() ======
+
+
+def test_parse_fields_count() -> None:
+    field_specs = parse_fields(DummyAttrs)
+    assert len(field_specs) == 2
+
+
+def test_parse_fields_types() -> None:
+    field_specs = parse_fields(DummyAttrs)
+    for fs in field_specs:
+        assert isinstance(fs, FieldSpec)
+
+
+def test_parse_fields_names() -> None:
+    field_specs = parse_fields(DummyAttrs)
+    names = [fs.name for fs in field_specs]
+    assert names == ["x", "y"]
+
+
+def test_parse_fields_mixed() -> None:
+    field_specs = parse_fields(MixedAttrs)
+    assert len(field_specs) == 4
+
+    assert field_specs[0].name == "id"
+    assert field_specs[0].default == UNSET
+    assert field_specs[0].nullable is False
+
+    assert field_specs[1].name == "name"
+    assert field_specs[1].default == "default"
+    assert field_specs[1].nullable is False
+
+    assert field_specs[2].name == "email"
+    assert field_specs[2].default is None
+
+    assert field_specs[3].name == "age"
+    assert field_specs[3].element is not None
+    assert field_specs[3].element.field_type is int
+    assert field_specs[3].default == 18
+    assert field_specs[3].nullable is False
+
+
+# ====== TESTS FOR parse() ======
+
+
+def test_parse_creates_model_spec() -> None:
+    spec = parse(DummyAttrs)
+    assert isinstance(spec, ModelSpec)
+
+
+def test_parse_model_name() -> None:
+    spec = parse(DummyAttrs)
+    assert spec.name == "DummyAttrs"
+
+
+def test_parse_model_type() -> None:
+    spec = parse(DummyAttrs)
+    assert spec.type == "attrs"
+
+
+def test_parse_model_fields() -> None:
+    spec = parse(DummyAttrs)
+    assert isinstance(spec.fields, tuple)
+    assert len(spec.fields) == 2
+
+
+def test_parse_mixed_model() -> None:
+    spec = parse(MixedAttrs)
+    assert spec.name == "MixedAttrs"
+    assert len(spec.fields) == 4
+
+    id_field = spec.fields[0]
+    assert id_field.name == "id"
+    assert id_field.default == UNSET
+    assert id_field.has_default() is False
+
+
+def test_parse_not_attrs_raises() -> None:
+    with pytest.raises(ResolutionError):
+        parse(NotAttrs)
+
+
+def test_parse_get_field_method() -> None:
+    spec = parse(DummyAttrs)
+    field = spec.get_field("x")
+    assert field.name == "x"
+    assert field.element is not None
+    assert field.element.field_type is int
+
+
+def test_parse_get_field_not_found() -> None:
+    spec = parse(DummyAttrs)
+    with pytest.raises(KeyError):
+        spec.get_field("nonexistent")
+
+
+def test_parse_get_required_fields() -> None:
+    spec = parse(MixedAttrs)
+    required = spec.get_requiered_fields()
+    assert len(required) == 1
+    assert required[0].name == "id"
+
+
+def test_parse_get_optional_fields() -> None:
+    spec = parse(MixedAttrs)
+    optional = spec.get_optional_fields()
+    assert len(optional) == 1
+    names = [f.name for f in optional]
+    assert "email" in names
+
+
+# ====== EDGE CASES ======
+
+
+def test_empty_attrs() -> None:
+    @attrs.define
+    class EmptyAttrs:
+        pass
+
+    spec = parse(EmptyAttrs)
+    assert spec.name == "EmptyAttrs"
+    assert len(spec.fields) == 0
+
+
+def test_attrs_with_only_defaults() -> None:
+    @attrs.define
+    class AllDefaults:
+        x: int = 1
+        y: str = "default"
+
+    spec = parse(AllDefaults)
+    assert all(f.has_default() for f in spec.fields)
+
+
+def test_attrs_with_private_fields() -> None:
+    @attrs.define
+    class PrivateFields:
+        _private: str = "private"
+        public: str = "public"
+
+    spec = parse(PrivateFields)
+    assert len(spec.fields) == 2
+    assert spec.fields[0].name == "_private"
+
+
+def test_parse_is_consistent() -> None:
+    spec1 = parse(MixedAttrs)
+    spec2 = parse(MixedAttrs)
+    assert spec1 is spec2
+
+
+# ===== Nested models ======
+Name = Annotated[str, MinLength(3), MaxLength(50)]
+
+
+@attrs.define
+class PermissionsAttrs:
+    name: Name
+    id: int
+
+
+@attrs.define
+class RoleAttrs:
+    name: Name
+    id: int
+    permissions: PermissionsAttrs
+
+
+@attrs.define
+class GroupAttrs:
+    name: Name
+    id: int
+
+
+@attrs.define
+class UserAttrs:
+    id: int
+    name: Name
+    age: Annotated[int, GreaterOrEqual(18), LessOrEqual(120)]
+    email: Email
+    role: RoleAttrs
+    group: GroupAttrs
+
+
+def test_parse_nested_models() -> None:
+    spec = parse(UserAttrs)
+
+    assert spec.name == "UserAttrs"
+    assert len(spec.fields) == 6
+
+    role_field = next(f for f in spec.fields if f.name == "role")
+    assert role_field.element is not None
+    assert role_field.element.nested_model is not None
+    assert role_field.element.nested_model.name == "RoleAttrs"
+
+    permissions_field = next(
+        f for f in role_field.element.nested_model.fields if f.name == "permissions"
+    )
+    assert permissions_field.element is not None
+    assert permissions_field.element.nested_model is not None
+    assert permissions_field.element.nested_model.name == "PermissionsAttrs"
+
+    name_field = next(f for f in spec.fields if f.name == "name")
+    assert name_field.element is not None
+    assert len(name_field.element.constraints) == 2
+    assert any(isinstance(c, MinLength) for c in name_field.element.constraints)
+
+
+def test_parse_attrs_with_list_fields() -> None:
+    spec = parse(ListFieldAttrs)
+
+    assert len(spec.fields) == 5
+
+    text = spec.fields[0]
+    emails = spec.fields[1]
+    names = spec.fields[2]
+    model_list = spec.fields[3]
+    unique_items = spec.fields[4]
+
+    assert text.collection_type is None
+
+    assert emails.item is not None
+    assert emails.item.field_type is Email
+    assert emails.collection_type is list
+
+    assert names.item is not None
+    assert names.item.field_type is str
+    assert names.collection_type is list
+    assert len(names.item.constraints) == 2
+    assert len(names.collection_constraints) == 2
+
+    assert model_list.item is not None
+    assert model_list.item.field_type is DefaultAttrs
+    assert model_list.item.nested_model is not None
+    assert model_list.collection_type is list
+
+    assert unique_items.item is not None
+    assert unique_items.item.field_type is str
+    assert unique_items.collection_type is set
+    assert unique_items.collection_constraints == (UniqueItems(True),)
+
+
+def test_parse_attrs_with_dict_fields() -> None:
+    spec = parse(DictFieldAttrs)
+
+    assert len(spec.fields) == 4
+
+    text = spec.fields[0]
+    emails = spec.fields[1]
+    models = spec.fields[2]
+    annotated_dicts = spec.fields[3]
+
+    assert text.collection_type is None
+
+    assert emails.collection_type is dict
+    assert emails.key is not None
+    assert emails.key.field_type is str
+    assert emails.value is not None
+    assert emails.value.field_type is Email
+
+    assert models.collection_type is dict
+    assert models.key is not None
+    assert models.key.field_type is str
+    assert models.value is not None
+    assert models.value.field_type is DefaultAttrs
+    assert models.value.nested_model is not None
+
+    assert annotated_dicts.collection_type is dict
+    assert annotated_dicts.collection_constraints == (MinItems(4),)
+    assert annotated_dicts.key is not None
+    assert annotated_dicts.key.constraints == (MinLength(5),)
+    assert annotated_dicts.value is not None
+    assert annotated_dicts.value.constraints == (MaxLength(10),)

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +142,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "attrs" },
+    { name = "email-validator" },
+    { name = "pydantic" },
+]
+attrs = [
+    { name = "attrs" },
+]
 pydantic = [
     { name = "email-validator" },
     { name = "pydantic" },
@@ -151,11 +168,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "attrs", marker = "extra == 'all'", specifier = ">=23.0.0" },
+    { name = "attrs", marker = "extra == 'attrs'", specifier = ">=23.0.0" },
+    { name = "email-validator", marker = "extra == 'all'", specifier = ">=2.0.0" },
     { name = "email-validator", marker = "extra == 'pydantic'", specifier = ">=2.0.0" },
+    { name = "pydantic", marker = "extra == 'all'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.0.0,<3.0.0" },
     { name = "rstr", specifier = ">=3.2.2" },
 ]
-provides-extras = ["pydantic"]
+provides-extras = ["pydantic", "attrs", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

 - Added basic support for parsing `attrs` models. Constraints now takes only from `Annotated`, support for `attrs` validators will be added later.
 - Updated CI test matrix for better coverage.

___

## Related issues

Closes #77 

---

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] perf (perfomance improvement)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [ ] chore (ci, tooling, dependencies)

---

## Scope

Affected module(s):

- [ ] resolver
- [ ] planner
- [ ] generators
- [ ] constraints
- [x] parsing
- [ ] api
- [ ] pytest
- [ ] docs
- [x] ci

---

## Breking changes

- [ ] Yes
- [x] No

---

## Tests

- [x] Unit tests added
- [ ] Existing tests updated
- [ ] No tests needed

---

## Checklist

- [x] Commit message follows project convention
- [x] CHANGELOG updated
- [x] README updated (if needed)
- [ ] Version increased (if needed)
